### PR TITLE
Add continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+cache: pip
+dist: xenial
+
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=py36
+
+install:
+  - pip install tox
+
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: xenial
 
 matrix:
   include:
+    - python: 2.7
+      env: TOXENV=py27
     - python: 3.6
       env: TOXENV=py36
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(),
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
-    install_requires=["faculty", "mlflow", "six"],
+    install_requires=["faculty", "mlflow @ https://github.com/mlflow/mlflow/tarball/master", "six"],
     entry_points={
         "mlflow.tracking_store": "faculty=mlflow_faculty:FacultyRestStore"
     },


### PR DESCRIPTION
This adds a CI pipeline for tests on Python 2.7 and 3.6 (the only two Python versions supported by mlflow).

We will add black and flake8 support in a separate PR to avoid polluting this with a large diff.