### PR TITLE
Get single run

### DIFF
--- a/mlflow_faculty/mlflow_converters.py
+++ b/mlflow_faculty/mlflow_converters.py
@@ -52,7 +52,7 @@ def faculty_run_to_mlflow_run(faculty_run):
         else None
     )
     run_info = RunInfo(
-        faculty_run.id,
+        faculty_run.id.hex,
         faculty_run.experiment_id,
         "",  # name
         "",  # source_type

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -163,13 +163,16 @@ class FacultyRestStore(AbstractStore):
         """
         Fetches the run from backend store
 
-        :param run_uuid: Unique identifier for the run
+        :param run_uuid: string containing run UUID 
+            (32 hex characters = a uuid4 stripped off of dashes)
 
         :return: A single :py:class:`mlflow.entities.Run` object if it exists,
             otherwise raises an exception
         """
         try:
-            faculty_run = self._client.get_run(self._project_id, run_uuid)
+            faculty_run = self._client.get_run(
+                self._project_id, UUID(run_uuid)
+            )
         except faculty.clients.base.HttpError as e:
             raise MlflowException(
                 "{}. Received response {} with status code {}".format(

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -168,7 +168,17 @@ class FacultyRestStore(AbstractStore):
         :return: A single :py:class:`mlflow.entities.Run` object if it exists,
             otherwise raises an exception
         """
-        raise NotImplementedError()
+        try:
+            faculty_run = self._client.get_run(self._project_id, run_uuid)
+        except faculty.clients.base.HttpError as e:
+            raise MlflowException(
+                "{}. Received response {} with status code {}".format(
+                    e.error, e.response.text, e.response.status_code
+                )
+            )
+        else:
+            mlflow_run = faculty_run_to_mlflow_run(faculty_run)
+            return mlflow_run
 
     def update_run_info(self, run_uuid, run_status, end_time):
         """

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "faculty @ git+https://github.com/facultyai/faculty.git#egg=faculty",
+        "faculty @ git+https://github.com/facultyai/faculty.git@get-single-run#egg=faculty",
         "mlflow @ git+https://github.com/mlflow/mlflow.git#egg=mlflow",
         "six",
         "pytz"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "faculty @ git+https://github.com/facultyai/faculty.git@get-single-run#egg=faculty",
+        "faculty @ git+https://github.com/facultyai/faculty.git#egg=faculty",
         "mlflow @ git+https://github.com/mlflow/mlflow.git#egg=mlflow",
         "six",
         "pytz",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "faculty @ git+https://github.com/facultyai/faculty.git@get-single-run#egg=faculty",
         "mlflow @ git+https://github.com/mlflow/mlflow.git#egg=mlflow",
         "six",
-        "pytz"
+        "pytz",
     ],
     entry_points={
         "mlflow.tracking_store": "faculty=mlflow_faculty:FacultyRestStore"

--- a/tests/test_mlflow_converters.py
+++ b/tests/test_mlflow_converters.py
@@ -19,12 +19,13 @@ from mlflow_faculty.mlflow_converters import (
 )
 from mlflow_faculty.py23 import to_timestamp
 
-EXPERIMENT_RUN_ID = uuid4()
+EXPERIMENT_RUN_UUID = uuid4()
+EXPERIMENT_RUN_UUID_HEX_STR = EXPERIMENT_RUN_UUID.hex
 RUN_STARTED_AT = datetime(2018, 3, 10, 11, 39, 12, 110000, tzinfo=UTC)
 RUN_STARTED_AT_INT = to_timestamp(RUN_STARTED_AT) * 1000
 
 FACULTY_RUN = FacultyExperimentRun(
-    id=EXPERIMENT_RUN_ID,
+    id=EXPERIMENT_RUN_UUID,
     experiment_id=661,
     artifact_location="faculty:",
     status=FacultyExperimentRunStatus.RUNNING,
@@ -35,7 +36,7 @@ FACULTY_RUN = FacultyExperimentRun(
 
 
 EXPECTED_RUN_INFO = RunInfo(
-    EXPERIMENT_RUN_ID,
+    EXPERIMENT_RUN_UUID_HEX_STR,
     661,
     "",  # name
     "",  # source_type

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -19,11 +19,16 @@ from pytz import UTC
 
 import faculty
 from faculty.clients.base import HttpError
-from faculty.clients.experiment import Experiment, ExperimentRun, ExperimentRunStatus
+from faculty.clients.experiment import (
+    Experiment,
+    ExperimentRun,
+    ExperimentRunStatus,
+)
 from mlflow.entities import Experiment as MLExperiment, LifecycleStage
 from mlflow.exceptions import MlflowException
 import pytest
 
+from mlflow_faculty.mlflow_converters import faculty_run_to_mlflow_run
 from mlflow_faculty.trackingstore import FacultyRestStore
 from mlflow_faculty.py23 import to_timestamp
 
@@ -51,16 +56,14 @@ FACULTY_EXPERIMENT = Experiment(
     deleted_at=None,
 )
 
-EXPERIMENT_RUN_ID = uuid4()
-
 FACULTY_EXPERIMENT_RUN = ExperimentRun(
-    id=EXPERIMENT_RUN_ID,
+    id=uuid4(),
     experiment_id=FACULTY_EXPERIMENT.id,
     artifact_location="faculty:",
     status=ExperimentRunStatus.RUNNING,
-    started_at=RUN_STARTED_AT,
-    ended_at=RUN_ENDED_AT,
-    deleted_at=DELETED_AT,
+    started_at=datetime.now(tz=UTC),
+    ended_at=datetime.now(tz=UTC),
+    deleted_at=datetime.now(tz=UTC),
 )
 
 
@@ -219,10 +222,7 @@ def test_create_run(mocker):
 
     # this is how Mlflow creates the start time
     start_time = time.time() * 1000
-    expected_start_time = datetime.fromtimestamp(
-        start_time / 1000,
-        tz=UTC
-    )
+    expected_start_time = datetime.fromtimestamp(start_time / 1000, tz=UTC)
 
     store = FacultyRestStore(STORE_URI)
 
@@ -265,18 +265,39 @@ def test_create_run_client_error(mocker):
             "parent-run-id",
         )
 
+
 def test_get_run(mocker):
     mock_client = mocker.Mock()
     mock_client.get_run.return_value = FACULTY_EXPERIMENT_RUN
     mocker.patch("faculty.client", return_value=mock_client)
     mock_mlflow_run = mocker.Mock()
-    mocker.patch(
+    converter_mock = mocker.patch(
         "mlflow_faculty.trackingstore.faculty_run_to_mlflow_run",
         return_value=mock_mlflow_run,
     )
 
     store = FacultyRestStore(STORE_URI)
-    run = store.get_run(EXPERIMENT_RUN_ID)
+    run = store.get_run(FACULTY_EXPERIMENT_RUN.id)
 
     assert run == mock_mlflow_run
-    mock_client.get_run.assert_called_once_with(PROJECT_ID, EXPERIMENT_RUN_ID)
+
+    mock_client.get_run.assert_called_once_with(
+        PROJECT_ID, FACULTY_EXPERIMENT_RUN.id
+    )
+    converter_mock.assert_called_once_with(FACULTY_EXPERIMENT_RUN)
+
+
+def test_get_run_client_error(mocker):
+    mock_client = mocker.Mock()
+    mock_client.get_run.side_effect = HttpError(
+        mocker.Mock(), "Experiment run with ID _ not found in project _"
+    )
+    mocker.patch("faculty.client", return_value=mock_client)
+
+    store = FacultyRestStore(STORE_URI)
+
+    with pytest.raises(
+        MlflowException,
+        match="Experiment run with ID _ not found in project _",
+    ):
+        store.get_run(EXPERIMENT_ID)

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -56,8 +56,11 @@ FACULTY_EXPERIMENT = Experiment(
     deleted_at=None,
 )
 
+EXPERIMENT_RUN_UUID = uuid4()
+EXPERIMENT_RUN_UUID_HEX_STR = EXPERIMENT_RUN_UUID.hex
+
 FACULTY_EXPERIMENT_RUN = ExperimentRun(
-    id=uuid4(),
+    id=EXPERIMENT_RUN_UUID,
     experiment_id=FACULTY_EXPERIMENT.id,
     artifact_location="faculty:",
     status=ExperimentRunStatus.RUNNING,
@@ -277,12 +280,12 @@ def test_get_run(mocker):
     )
 
     store = FacultyRestStore(STORE_URI)
-    run = store.get_run(FACULTY_EXPERIMENT_RUN.id)
+    run = store.get_run(EXPERIMENT_RUN_UUID_HEX_STR)
 
     assert run == mock_mlflow_run
 
     mock_client.get_run.assert_called_once_with(
-        PROJECT_ID, FACULTY_EXPERIMENT_RUN.id
+        PROJECT_ID, EXPERIMENT_RUN_UUID
     )
     converter_mock.assert_called_once_with(FACULTY_EXPERIMENT_RUN)
 
@@ -300,4 +303,4 @@ def test_get_run_client_error(mocker):
         MlflowException,
         match="Experiment run with ID _ not found in project _",
     ):
-        store.get_run(EXPERIMENT_ID)
+        store.get_run(EXPERIMENT_RUN_UUID_HEX_STR)


### PR DESCRIPTION
This PR implements getting single runs from the store.

To be merged after PR #3 .

Depends on https://github.com/facultyai/faculty/pull/78.

I've tested it like this

```python
import os
os.environ["MLFLOW_TRACKING_URI"] = "faculty:{}".format(os.environ["FACULTY_PROJECT_ID"])
import mlflow
from mlflow.tracking.utils import _get_store

store = _get_store()

started_run = mlflow.start_run()
retrieved_run = store.get_run(started_run.info.run_uuid)
```

I've also fixed the confusion around UUIDs. 

- the mlflow layer uses UUID4s as strings without dashes (32 chars)
- our models (from `faculty` library) use normal UUID types
- it's responsibility of the faculty tracking store to convert between these 2

This UUID fix now allows for using the MlflowClient like this:

```python
from mlflow.tracking.client import MlflowClient
client = MlflowClient()
client.get_run(started_run.info.run_uuid)
```

TODO
- [x] change target branch to master after #3 is merged