### PR TITLE
Remove slash from suggested URI

### DIFF
--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -36,9 +36,7 @@ class FacultyRestStore(AbstractStore):
         elif parsed_uri.netloc != "":
             raise ValueError(
                 "Invalid URI {}. Netloc is reserved. "
-                "Did you mean 'faculty:/{}".format(
-                    store_uri, parsed_uri.netloc
-                )
+                "Did you mean 'faculty:{}".format(store_uri, parsed_uri.netloc)
             )
 
         cleaned_path = parsed_uri.path.strip("/")

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -111,7 +111,7 @@ def test_init_invalid_uri_in_netloc():
     store_uri = "faculty://{}".format(PROJECT_ID)
     expected_error_message = (
         "Invalid URI {}. Netloc is reserved. "
-        "Did you mean 'faculty:/{}".format(store_uri, PROJECT_ID)
+        "Did you mean 'faculty:{}".format(store_uri, PROJECT_ID)
     )
     with pytest.raises(ValueError, match=expected_error_message):
         FacultyRestStore(store_uri)


### PR DESCRIPTION
The cleanest way to specify a faculty tracking store will be like `faculty:9229d92c-d487-4ca5-91f7-81fc362734ae` rather than `faculty:/9229d92c-d487-4ca5-91f7-81fc362734ae`, so our suggested one should reflect that.