### PR TITLE
Implement search_runs() in the tracking store

### DIFF
--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -319,3 +319,6 @@ class FacultyRestStore(AbstractStore):
             )
         else:
             return [faculty_run_to_mlflow_run(run) for run in faculty_runs]
+
+    def log_batch(self, run_id, metrics, params, tags):
+        raise NotImplementedError()

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -305,7 +305,10 @@ class FacultyRestStore(AbstractStore):
                     self._project_id, experiment_ids=experiment_ids
                 )
                 faculty_runs.extend(list_runs_response.runs)
-                if list_runs_response.pagination.next is None:
+                if (
+                    list_runs_response.pagination.next is None
+                    or len(list_runs_response.runs) == 0
+                ):
                     break
         except faculty.clients.base.HttpError as e:
             raise MlflowException(

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -174,7 +174,7 @@ class FacultyRestStore(AbstractStore):
             )
         except faculty.clients.base.HttpError as e:
             raise MlflowException(
-                "{}. Received response {} with status code {}".format(
+                "Failed to get run: {}. Received response {} with status code {}".format(
                     e.error, e.response.text, e.response.status_code
                 )
             )

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -304,7 +304,7 @@ class FacultyRestStore(AbstractStore):
                 list_runs_response = self._client.list_runs(
                     self._project_id, experiment_ids=experiment_ids
                 )
-                faculty_runs += list_runs_response.runs
+                faculty_runs.extend(list_runs_response.runs)
                 if list_runs_response.pagination.next is None:
                     break
         except faculty.clients.base.HttpError as e:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "faculty @ git+https://github.com/facultyai/faculty.git@list-experiment-runs#egg=faculty",
+        "faculty @ git+https://github.com/facultyai/faculty.git"
+        "@list-experiment-runs#egg=faculty",
         "mlflow @ git+https://github.com/mlflow/mlflow.git#egg=mlflow",
         "six",
         "pytz",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "faculty @ git+https://github.com/facultyai/faculty.git#egg=faculty",
+        "faculty @ git+https://github.com/facultyai/faculty.git@list-experiment-runs#egg=faculty",
         "mlflow @ git+https://github.com/mlflow/mlflow.git#egg=mlflow",
         "six",
         "pytz",

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ setup(
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "faculty @ git+https://github.com/facultyai/faculty.git"
-        "@list-experiment-runs#egg=faculty",
+        "faculty @ git+https://github.com/facultyai/faculty.git#egg=faculty",
         "mlflow @ git+https://github.com/mlflow/mlflow.git#egg=mlflow",
         "six",
         "pytz",

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -376,6 +376,29 @@ def test_search_runs_empty_page(mocker):
     )
 
 
+def test_search_runs_next_page_but_no_runs(mocker):
+    list_page = ListExperimentRunsResponse(
+        runs=[],
+        pagination=Pagination(
+            start=0, size=0, previous=None, next=Page(start=999, limit=999)
+        ),
+    )
+
+    mock_client = mocker.Mock()
+    mock_client.list_runs.side_effect = [list_page]
+    mocker.patch("faculty.client", return_value=mock_client)
+
+    store = FacultyRestStore(STORE_URI)
+    runs = store.search_runs(
+        experiment_ids=None, search_expressions=None, run_view_type=None
+    )
+
+    assert runs == []
+    mock_client.list_runs.assert_called_once_with(
+        PROJECT_ID, experiment_ids=None
+    )
+
+
 def test_search_runs_filter_by_experiment(mocker):
     list_page = ListExperimentRunsResponse(
         runs=[],

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -16,6 +16,7 @@ from datetime import datetime
 import time
 from uuid import uuid4
 from pytz import UTC
+from unittest.mock import call
 
 import faculty
 from faculty.clients.base import HttpError
@@ -23,6 +24,9 @@ from faculty.clients.experiment import (
     Experiment,
     ExperimentRun,
     ExperimentRunStatus,
+    ListExperimentRunsResponse,
+    Pagination,
+    Page,
 )
 from mlflow.entities import Experiment as MLExperiment, LifecycleStage
 from mlflow.exceptions import MlflowException
@@ -304,3 +308,108 @@ def test_get_run_client_error(mocker):
         match="Experiment run with ID _ not found in project _",
     ):
         store.get_run(EXPERIMENT_RUN_UUID_HEX_STR)
+
+
+def test_search_runs(mocker):
+    mock_faculty_runs = [mocker.Mock(), mocker.Mock(), mocker.Mock()]
+    list_page_1 = ListExperimentRunsResponse(
+        runs=[mock_faculty_runs[0], mock_faculty_runs[1]],
+        pagination=Pagination(
+            start=0, size=2, previous=None, next=Page(start=2, limit=1)
+        ),
+    )
+    list_page_2 = ListExperimentRunsResponse(
+        runs=[mock_faculty_runs[2]],
+        pagination=Pagination(
+            start=0, size=2, previous=Page(start=0, limit=2), next=None
+        ),
+    )
+
+    mock_client = mocker.Mock()
+    mock_client.list_runs.side_effect = [list_page_1, list_page_2]
+    mocker.patch("faculty.client", return_value=mock_client)
+
+    mock_mlflow_runs = [mocker.Mock(), mocker.Mock(), mocker.Mock()]
+    converter_mock = mocker.patch(
+        "mlflow_faculty.trackingstore.faculty_run_to_mlflow_run",
+        side_effect=mock_mlflow_runs,
+    )
+
+    store = FacultyRestStore(STORE_URI)
+    runs = store.search_runs(
+        experiment_ids=None, search_expressions=None, run_view_type=None
+    )
+
+    assert runs == mock_mlflow_runs
+    mock_client.list_runs.assert_has_calls(
+        [
+            call(PROJECT_ID, experiment_ids=None),
+            call(PROJECT_ID, experiment_ids=None),
+        ]
+    )
+    converter_mock.assert_has_calls(
+        [
+            call(mock_faculty_runs[0]),
+            call(mock_faculty_runs[1]),
+            call(mock_faculty_runs[2]),
+        ]
+    )
+
+
+def test_search_runs_empty_page(mocker):
+    list_page = ListExperimentRunsResponse(
+        runs=[],
+        pagination=Pagination(start=0, size=0, previous=None, next=None),
+    )
+
+    mock_client = mocker.Mock()
+    mock_client.list_runs.side_effect = [list_page]
+    mocker.patch("faculty.client", return_value=mock_client)
+
+    store = FacultyRestStore(STORE_URI)
+    runs = store.search_runs(
+        experiment_ids=None, search_expressions=None, run_view_type=None
+    )
+
+    assert runs == []
+    mock_client.list_runs.assert_called_once_with(
+        PROJECT_ID, experiment_ids=None
+    )
+
+
+def test_search_runs_filter_by_experiment(mocker):
+    list_page = ListExperimentRunsResponse(
+        runs=[],
+        pagination=Pagination(start=0, size=0, previous=None, next=None),
+    )
+
+    mock_client = mocker.Mock()
+    mock_client.list_runs.side_effect = [list_page]
+    mocker.patch("faculty.client", return_value=mock_client)
+
+    store = FacultyRestStore(STORE_URI)
+    runs = store.search_runs(
+        experiment_ids=[123, 456], search_expressions=None, run_view_type=None
+    )
+
+    assert runs == []
+    mock_client.list_runs.assert_called_once_with(
+        PROJECT_ID, experiment_ids=[123, 456]
+    )
+
+
+def test_search_runs_client_error(mocker):
+    mock_client = mocker.Mock()
+    mock_client.list_runs.side_effect = HttpError(
+        mocker.Mock(), "Dummy client error."
+    )
+    mocker.patch("faculty.client", return_value=mock_client)
+
+    store = FacultyRestStore(STORE_URI)
+
+    with pytest.raises(MlflowException, match="Dummy client error."):
+        store.search_runs(
+            [FACULTY_EXPERIMENT.id],
+            search_expressions=None,
+            run_view_type=None,
+        )

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -16,7 +16,6 @@ from datetime import datetime
 import time
 from uuid import uuid4
 from pytz import UTC
-from unittest.mock import call
 
 import faculty
 from faculty.clients.base import HttpError
@@ -343,15 +342,15 @@ def test_search_runs(mocker):
     assert runs == mock_mlflow_runs
     mock_client.list_runs.assert_has_calls(
         [
-            call(PROJECT_ID, experiment_ids=None),
-            call(PROJECT_ID, experiment_ids=None),
+            mocker.call(PROJECT_ID, experiment_ids=None),
+            mocker.call(PROJECT_ID, experiment_ids=None),
         ]
     )
     converter_mock.assert_has_calls(
         [
-            call(mock_faculty_runs[0]),
-            call(mock_faculty_runs[1]),
-            call(mock_faculty_runs[2]),
+            mocker.call(mock_faculty_runs[0]),
+            mocker.call(mock_faculty_runs[1]),
+            mocker.call(mock_faculty_runs[2]),
         ]
     )
 


### PR DESCRIPTION
This can be testes e.g. like this:

```python
import os
os.environ["MLFLOW_TRACKING_URI"] = "faculty:{}".format(os.environ["FACULTY_PROJECT_ID"])
import mlflow
from mlflow.tracking.utils import _get_store

store = _get_store()
store.search_runs(
    experiment_ids=None,
    search_expressions=None,
    run_view_type=None
)
```

I've checked it with both Python2 and 3 environments.

Depends on https://github.com/facultyai/faculty/pull/79.

I had to add one empty stub of a method from the abstract store that was added to mlflow master today.