### PR TITLE
Implement artifact repository

### DIFF
--- a/mlflow_faculty/__init__.py
+++ b/mlflow_faculty/__init__.py
@@ -15,5 +15,5 @@
 
 from mlflow_faculty.trackingstore import FacultyRestStore  # noqa F401
 from mlflow_faculty.artifact_repository import (  # noqa F401
-    FacultyDatasetsArtifactRepository
+    FacultyDatasetsArtifactRepository,
 )

--- a/mlflow_faculty/__init__.py
+++ b/mlflow_faculty/__init__.py
@@ -14,3 +14,6 @@
 
 
 from mlflow_faculty.trackingstore import FacultyRestStore  # noqa F401
+from mlflow_faculty.artifact_repository import (  # noqa F401
+    FacultyDatasetsArtifactRepository
+)

--- a/mlflow_faculty/artifact_repository.py
+++ b/mlflow_faculty/artifact_repository.py
@@ -1,0 +1,86 @@
+# Copyright 2019 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from uuid import UUID
+from functools import partial
+
+from six.moves import urllib
+
+from faculty.datasets import session
+from mlflow.store.artifact_repo import ArtifactRepository
+from mlflow.store.s3_artifact_repo import S3ArtifactRepository
+
+
+class _S3ArtifactRepositoryWithClientOverride(S3ArtifactRepository):
+    def __init__(self, artifact_uri, client_factory):
+        super(_S3ArtifactRepositoryWithClientOverride, self).__init__(
+            artifact_uri
+        )
+        self._client_factory = client_factory
+
+    def _get_s3_client(self):
+        return self._client_factory()
+
+
+class FacultyDatasetsArtifactRepository(ArtifactRepository):
+    def __init__(self, artifact_uri):
+        parsed_uri = urllib.parse.urlparse(artifact_uri)
+        if parsed_uri.scheme != "faculty-datasets":
+            raise ValueError(
+                "Not a Faculty datasets URI: {}".format(artifact_uri)
+            )
+        # Test for PROJECT_ID in netloc rather than path.
+        elif parsed_uri.netloc != "":
+            raise ValueError(
+                "Invalid URI {}. Netloc is reserved. "
+                "Did you mean 'faculty-datasets:{}{}'".format(
+                    artifact_uri, parsed_uri.netloc, parsed_uri.path
+                )
+            )
+
+        cleaned_path = parsed_uri.path.strip("/")
+        first_part = cleaned_path.split("/")[0]
+        try:
+            project_id = UUID(first_part)
+        except ValueError:
+            raise ValueError(
+                "{} in given URI {} is not a valid UUID".format(
+                    first_part, artifact_uri
+                )
+            )
+
+        self._session = session.get()
+        s3_bucket = self._session.bucket(project_id)
+        s3_uri = "s3://{}/{}".format(s3_bucket, cleaned_path)
+        s3_client_factory = partial(self._session.s3_client, project_id)
+
+        self._s3_repository = _S3ArtifactRepositoryWithClientOverride(
+            s3_uri, s3_client_factory
+        )
+
+    def get_path_module(self):
+        return self._s3_repository.get_path_module()
+
+    def log_artifact(self, local_file, artifact_path=None):
+        return self._s3_repository.log_artifact(local_file, artifact_path)
+
+    def log_artifacts(self, local_dir, artifact_path=None):
+        return self._s3_repository.log_artifacts(local_dir, artifact_path)
+
+    def list_artifacts(self, path):
+        return self._s3_repository.list_artifacts(path)
+
+    def _download_file(self, remote_file_path, local_path):
+        return self._s3_repository._download_file(remote_file_path, local_path)

--- a/mlflow_faculty/mlflow_converters.py
+++ b/mlflow_faculty/mlflow_converters.py
@@ -91,6 +91,7 @@ def faculty_run_to_mlflow_run(faculty_run):
         end_time,
         "",  # source version
         lifecycle_stage,
+        faculty_run.artifact_location,
     )
     run_data = RunData(
         tags=[faculty_tag_to_mlflow_tag(tag) for tag in faculty_run.tags]

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,12 @@
 from setuptools import setup, find_packages
 
 
+TRACKING_STORE_ENTRYPOINT = "faculty=mlflow_faculty:FacultyRestStore"
+ARTIFACT_REPOSITORY_ENTRYPOINT = (
+    "faculty-datasets=mlflow_faculty:FacultyDatasetsArtifactRepository"
+)
+
+
 setup(
     name="mlflow-faculty",
     description="MLflow plugin for the Faculty platform.",
@@ -33,6 +39,7 @@ setup(
         "pytz",
     ],
     entry_points={
-        "mlflow.tracking_store": "faculty=mlflow_faculty:FacultyRestStore"
+        "mlflow.tracking_store": TRACKING_STORE_ENTRYPOINT,
+        "mlflow.artifact_repository": ARTIFACT_REPOSITORY_ENTRYPOINT,
     },
 )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -77,7 +77,7 @@ RUN_STARTED_AT_MILLISECONDS = to_timestamp(RUN_STARTED_AT) * 1000
 FACULTY_RUN = ExperimentRun(
     id=RUN_UUID,
     experiment_id=FACULTY_EXPERIMENT.id,
-    artifact_location="faculty:",
+    artifact_location=ARTIFACT_LOCATION,
     status=ExperimentRunStatus.RUNNING,
     started_at=RUN_STARTED_AT,
     ended_at=None,
@@ -111,5 +111,6 @@ def mlflow_run(
         end_time,
         "",  # source_version
         lifecycle_stage,
+        ARTIFACT_LOCATION,
     )
     return Run(info, data)

--- a/tests/test_artifact_repository.py
+++ b/tests/test_artifact_repository.py
@@ -1,0 +1,158 @@
+# Copyright 2019 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from uuid import uuid4
+
+import pytest
+
+from mlflow_faculty.artifact_repository import (
+    _S3ArtifactRepositoryWithClientOverride,
+    FacultyDatasetsArtifactRepository,
+)
+
+
+PROJECT_ID = uuid4()
+ARTIFACT_URI = "faculty-datasets:{}/path/in/datasets".format(PROJECT_ID)
+S3_BUCKET_NAME = "faculty-datasets-s3-bucket"
+S3_URI = "s3://{}/{}/path/in/datasets".format(S3_BUCKET_NAME, PROJECT_ID)
+
+
+@pytest.fixture
+def mock_session(mocker):
+    session = mocker.Mock()
+    session.bucket.return_value = S3_BUCKET_NAME
+    mocker.patch("faculty.datasets.session.get", return_value=session)
+    return session
+
+
+@pytest.fixture
+def mock_s3_repo(mocker):
+    s3_repo = mocker.Mock()
+    mocker.patch(
+        "mlflow_faculty.artifact_repository."
+        "_S3ArtifactRepositoryWithClientOverride",
+        return_value=s3_repo,
+    )
+    return s3_repo
+
+
+def test_s3_repo_with_client_override(mocker):
+
+    artifact_uri = mocker.Mock()
+    s3_client_factory = mocker.Mock()
+
+    repo = _S3ArtifactRepositoryWithClientOverride(
+        artifact_uri, s3_client_factory
+    )
+
+    assert repo.artifact_uri == artifact_uri
+    assert repo._get_s3_client() == s3_client_factory.return_value
+
+
+@pytest.mark.parametrize("suffix", ["", "/"])
+def test_faculty_repo(mocker, mock_session, suffix):
+
+    s3_repo = mocker.Mock()
+    s3_repo_init = mocker.patch(
+        "mlflow_faculty.artifact_repository."
+        "_S3ArtifactRepositoryWithClientOverride",
+        return_value=s3_repo,
+    )
+
+    repo = FacultyDatasetsArtifactRepository(ARTIFACT_URI + suffix)
+
+    assert repo._s3_repository == s3_repo
+
+    # Check arguments that the S3 repo was built with
+    passed_uri, passed_client_factory = s3_repo_init.call_args[0]
+    # The first argument should be the correct S3 URI
+    assert passed_uri == S3_URI
+    # The second argument should be a function that builds an S3 client with
+    # the correct project ID
+    assert passed_client_factory() == mock_session.s3_client.return_value
+    mock_session.s3_client.assert_called_once_with(PROJECT_ID)
+
+
+@pytest.mark.parametrize(
+    "uri, message",
+    [
+        ("no/schema", "Not a Faculty datasets URI"),
+        ("wrong-schema:", "Not a Faculty datasets URI"),
+        (
+            "faculty-datasets://{}/path/in/datasets".format(PROJECT_ID),
+            "Invalid URI.*Did you mean '{}'".format(ARTIFACT_URI),
+        ),
+        ("faculty-datasets:invalid-uri", "is not a valid UUID"),
+    ],
+    ids=["No schema", "Wrong schema", "Double slash", "Invalid UUID"],
+)
+def test_faculty_repo_invalid_uri(uri, message):
+    with pytest.raises(ValueError, match=message):
+        FacultyDatasetsArtifactRepository(uri)
+
+
+def test_faculty_repo_get_path_module(mock_session, mock_s3_repo):
+    repo = FacultyDatasetsArtifactRepository(ARTIFACT_URI)
+    assert repo.get_path_module() == mock_s3_repo.get_path_module.return_value
+    mock_s3_repo.get_path_module.assert_called_once_with()
+
+
+def test_faculty_repo_log_artifact(mocker, mock_session, mock_s3_repo):
+    local_file = mocker.Mock()
+    artifact_path = mocker.Mock()
+    repo = FacultyDatasetsArtifactRepository(ARTIFACT_URI)
+
+    returned = repo.log_artifact(local_file, artifact_path)
+
+    assert returned == mock_s3_repo.log_artifact.return_value
+    mock_s3_repo.log_artifact.assert_called_once_with(
+        local_file, artifact_path
+    )
+
+
+def test_faculty_repo_log_artifacts(mocker, mock_session, mock_s3_repo):
+    local_file = mocker.Mock()
+    artifact_path = mocker.Mock()
+    repo = FacultyDatasetsArtifactRepository(ARTIFACT_URI)
+
+    returned = repo.log_artifacts(local_file, artifact_path)
+
+    assert returned == mock_s3_repo.log_artifacts.return_value
+    mock_s3_repo.log_artifacts.assert_called_once_with(
+        local_file, artifact_path
+    )
+
+
+def test_faculty_repo_list_artifacts(mocker, mock_session, mock_s3_repo):
+    path = mocker.Mock()
+    repo = FacultyDatasetsArtifactRepository(ARTIFACT_URI)
+
+    returned = repo.list_artifacts(path)
+
+    assert returned == mock_s3_repo.list_artifacts.return_value
+    mock_s3_repo.list_artifacts.assert_called_once_with(path)
+
+
+def test_faculty_repo_download_file(mocker, mock_session, mock_s3_repo):
+    remote_file_path = mocker.Mock()
+    local_path = mocker.Mock()
+    repo = FacultyDatasetsArtifactRepository(ARTIFACT_URI)
+
+    returned = repo._download_file(remote_file_path, local_path)
+
+    assert returned == mock_s3_repo._download_file.return_value
+    mock_s3_repo._download_file.assert_called_once_with(
+        remote_file_path, local_path
+    )

--- a/tests/test_mlflow_converters.py
+++ b/tests/test_mlflow_converters.py
@@ -50,7 +50,6 @@ from tests.fixtures import (
     mlflow_run,
 )
 
-
 DATETIME = datetime(2018, 3, 10, 11, 45, 32, 110000, tzinfo=UTC)
 DATETIME_MILLISECONDS = to_timestamp(DATETIME) * 1000
 


### PR DESCRIPTION
This PR implements an MLflow artifact repository and registers it with MLflow. Once installed, runs with an artifact location with a `faculty-datasets` scheme will store their artifacts in Faculty datasets.

As part of this PR, I extended the MLflow/Faculty run converter to pass the artifact location.