### PR TITLE
Add run context provider

### DIFF
--- a/mlflow_faculty/__init__.py
+++ b/mlflow_faculty/__init__.py
@@ -17,3 +17,4 @@ from mlflow_faculty.trackingstore import FacultyRestStore  # noqa F401
 from mlflow_faculty.artifact_repository import (  # noqa F401
     FacultyDatasetsArtifactRepository,
 )
+from mlflow_faculty.context import FacultyRunContext  # noqa F401

--- a/mlflow_faculty/context.py
+++ b/mlflow_faculty/context.py
@@ -1,0 +1,47 @@
+import os
+
+import faculty
+from mlflow.tracking.context import RunContextProvider
+
+
+FACULTY_ENV_TAGS = [
+    ("FACULTY_PROJECT_ID", "mlflow.faculty.project.projectId"),
+    ("FACULTY_SERVER_ID", "mlflow.faculty.server.serverId"),
+    ("FACULTY_SERVER_NAME", "mlflow.faculty.server.name"),
+    ("NUM_CPUS", "mlflow.faculty.server.cpus"),
+    ("AVAILABLE_MEMORY_MB", "mlflow.faculty.server.memoryMb"),
+    ("NUM_GPUS", "mlflow.faculty.server.gpus"),
+    ("FACULTY_JOB_ID", "mlflow.faculty.job.jobId"),
+    ("FACULTY_JOB_NAME", "mlflow.faculty.job.name"),
+    ("FACULTY_RUN_ID", "mlflow.faculty.job.runId"),
+    ("FACULTY_RUN_NUMBER", "mlflow.faculty.job.runNumber"),
+    ("FACULTY_SUBRUN_ID", "mlflow.faculty.job.subrunId"),
+    ("FACULTY_SUBRUN_NUMBER", "mlflow.faculty.job.subrunNumber"),
+]
+
+USER_ID_TAG = "mlflow.faculty.user.userId"
+
+
+class FacultyRunContext(RunContextProvider):
+    def __init__(self):
+        self._user_id_cache = None
+
+    @property
+    def _user_id(self):
+        if self._user_id_cache is None:
+            client = faculty.client("account")
+            self._user_id_cache = client.authenticated_user_id()
+        return self._user_id_cache
+
+    def in_context(self):
+        return "FACULTY_PROJECT_ID" in os.environ
+
+    def tags(self):
+        tags = {}
+        for environment_variable, tag_name in FACULTY_ENV_TAGS:
+            try:
+                tags[tag_name] = os.environ[environment_variable]
+            except KeyError:
+                pass
+        tags[USER_ID_TAG] = self._user_id()
+        return tags

--- a/mlflow_faculty/context.py
+++ b/mlflow_faculty/context.py
@@ -43,5 +43,8 @@ class FacultyRunContext(RunContextProvider):
                 tags[tag_name] = os.environ[environment_variable]
             except KeyError:
                 pass
-        tags[USER_ID_TAG] = self._user_id()
+        try:
+            tags[USER_ID_TAG] = self._user_id
+        except Exception:
+            pass
         return tags

--- a/mlflow_faculty/context.py
+++ b/mlflow_faculty/context.py
@@ -44,7 +44,7 @@ class FacultyRunContext(RunContextProvider):
             except KeyError:
                 pass
         try:
-            tags[USER_ID_TAG] = self._user_id
+            tags[USER_ID_TAG] = str(self._user_id)
         except Exception:
             pass
         return tags

--- a/mlflow_faculty/context.py
+++ b/mlflow_faculty/context.py
@@ -48,15 +48,14 @@ class FacultyRunContext(RunContextProvider):
         return self._user_id_cache
 
     def in_context(self):
-        return "FACULTY_PROJECT_ID" in os.environ
+        return bool(os.environ.get("FACULTY_PROJECT_ID"))
 
     def tags(self):
         tags = {}
         for environment_variable, tag_name in FACULTY_ENV_TAGS:
-            try:
-                tags[tag_name] = os.environ[environment_variable]
-            except KeyError:
-                pass
+            value = os.environ.get(environment_variable)
+            if value:
+                tags[tag_name] = value
         try:
             tags[USER_ID_TAG] = str(self._user_id)
         except Exception:

--- a/mlflow_faculty/context.py
+++ b/mlflow_faculty/context.py
@@ -15,7 +15,8 @@
 import os
 
 import faculty
-from mlflow.tracking.context import RunContextProvider
+
+# from mlflow.tracking.context import RunContextProvider
 
 
 FACULTY_ENV_TAGS = [
@@ -36,7 +37,7 @@ FACULTY_ENV_TAGS = [
 USER_ID_TAG = "mlflow.faculty.user.userId"
 
 
-class FacultyRunContext(RunContextProvider):
+class FacultyRunContext:  # TODO: This should inherit from RunContextProvider
     def __init__(self):
         self._user_id_cache = None
 

--- a/mlflow_faculty/context.py
+++ b/mlflow_faculty/context.py
@@ -33,6 +33,8 @@ FACULTY_ENV_TAGS = [
     ("FACULTY_RUN_NUMBER", "mlflow.faculty.job.runNumber"),
     ("FACULTY_SUBRUN_ID", "mlflow.faculty.job.subrunId"),
     ("FACULTY_SUBRUN_NUMBER", "mlflow.faculty.job.subrunNumber"),
+    ("FACULTY_APP_ID", "mlflow.faculty.app.appId"),
+    ("FACULTY_API_ID", "mlflow.faculty.api.apiId"),
 ]
 
 USER_ID_TAG = "mlflow.faculty.user.userId"

--- a/mlflow_faculty/context.py
+++ b/mlflow_faculty/context.py
@@ -1,3 +1,17 @@
+# Copyright 2019 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 import faculty

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ TRACKING_STORE_ENTRYPOINT = "faculty=mlflow_faculty:FacultyRestStore"
 ARTIFACT_REPOSITORY_ENTRYPOINT = (
     "faculty-datasets=mlflow_faculty:FacultyDatasetsArtifactRepository"
 )
+RUN_CONTEXT_ENTRYPOINT = "faculty-run-context=mlflow_faculty:FacultyRunContext"
 
 
 setup(
@@ -41,5 +42,6 @@ setup(
     entry_points={
         "mlflow.tracking_store": TRACKING_STORE_ENTRYPOINT,
         "mlflow.artifact_repository": ARTIFACT_REPOSITORY_ENTRYPOINT,
+        "mlflow.run_context_provider": RUN_CONTEXT_ENTRYPOINT,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ TRACKING_STORE_ENTRYPOINT = "faculty=mlflow_faculty:FacultyRestStore"
 ARTIFACT_REPOSITORY_ENTRYPOINT = (
     "faculty-datasets=mlflow_faculty:FacultyDatasetsArtifactRepository"
 )
-RUN_CONTEXT_ENTRYPOINT = "faculty-run-context=mlflow_faculty:FacultyRunContext"
+RUN_CONTEXT_ENTRYPOINT = (
+    "faculty-run-context=mlflow_faculty.context:FacultyRunContext"
+)
 
 
 setup(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -15,7 +15,6 @@
 from uuid import uuid4
 
 import pytest
-import mock
 
 from mlflow_faculty.context import FacultyRunContext
 
@@ -27,7 +26,8 @@ def merge_dicts(*dicts):
     return merged
 
 
-MOCK_ACCOUNT = mock.Mock(user_id=uuid4(), username="joe_bloggs")
+USER_ID = uuid4()
+USERNAME = "joe_bloggs"
 
 STANDARD_ENVIRONMENT = {
     "FACULTY_PROJECT_ID": "project-id",
@@ -66,8 +66,8 @@ STANDARD_TAGS = {
     "mlflow.faculty.server.gpus": "1",
 }
 USER_TAGS = {
-    "mlflow.faculty.user.userId": str(MOCK_ACCOUNT.user_id),
-    "mlflow.faculty.user.username": MOCK_ACCOUNT.username,
+    "mlflow.faculty.user.userId": str(USER_ID),
+    "mlflow.faculty.user.username": USERNAME,
 }
 JOB_TAGS = {
     "mlflow.faculty.createdBy": "job",
@@ -147,7 +147,8 @@ def test_tags(
 
     mock_client = mocker.Mock()
     if account_available:
-        mock_client.authenticated_account.return_value = MOCK_ACCOUNT
+        account = mocker.Mock(user_id=USER_ID, username=USERNAME)
+        mock_client.authenticated_account.return_value = account
     else:
         mock_client.authenticated_account.side_effect = Exception()
     mocker.patch("faculty.client", return_value=mock_client)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,77 @@
+# Copyright 2019 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from uuid import uuid4
+
+import pytest
+
+from mlflow_faculty.context import FacultyRunContext
+
+
+USER_ID = uuid4()
+
+
+@pytest.mark.parametrize(
+    "env, in_context",
+    [
+        ({"FACULTY_PROJECT_ID": "project-id"}, True),
+        ({"FACULTY_PROJECT_ID": ""}, False),
+        ({}, False),
+    ],
+)
+def test_in_context(mocker, env, in_context):
+    mocker.patch("os.environ", env)
+    assert FacultyRunContext().in_context() is in_context
+
+
+def test_tags(mocker):
+    mocker.patch(
+        "os.environ",
+        {
+            "FACULTY_PROJECT_ID": "project-id",
+            "FACULTY_SERVER_ID": "server-id",
+            "FACULTY_SERVER_NAME": "server-name",
+            "NUM_CPUS": "4",
+            "AVAILABLE_MEMORY_MB": "4000",
+            "NUM_GPUS": "1",
+            "FACULTY_JOB_ID": "job-id",
+            "FACULTY_JOB_NAME": "job-name",
+            "FACULTY_RUN_ID": "run-id",
+            "FACULTY_RUN_NUMBER": "23",
+            "FACULTY_SUBRUN_ID": "subrun-id",
+            "FACULTY_SUBRUN_NUMBER": "2",
+        },
+    )
+
+    mock_client = mocker.Mock()
+    mock_client.authenticated_user_id.return_value = USER_ID
+    mocker.patch("faculty.client", return_value=mock_client)
+
+    expected_tags = {
+        "mlflow.faculty.user.userId": str(USER_ID),
+        "mlflow.faculty.project.projectId": "project-id",
+        "mlflow.faculty.server.serverId": "server-id",
+        "mlflow.faculty.server.name": "server-name",
+        "mlflow.faculty.server.cpus": "4",
+        "mlflow.faculty.server.memoryMb": "4000",
+        "mlflow.faculty.server.gpus": "1",
+        "mlflow.faculty.job.jobId": "job-id",
+        "mlflow.faculty.job.name": "job-name",
+        "mlflow.faculty.job.runId": "run-id",
+        "mlflow.faculty.job.runNumber": "23",
+        "mlflow.faculty.job.subrunId": "subrun-id",
+        "mlflow.faculty.job.subrunNumber": "2",
+    }
+
+    assert FacultyRunContext().tags() == expected_tags

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -47,6 +47,9 @@ JOB_ENVIRONMENT = {
     "FACULTY_SUBRUN_ID": "subrun-id",
     "FACULTY_SUBRUN_NUMBER": "2",
 }
+APP_ENVIRONMENT = {"FACULTY_SERVER_TYPE": "app"}
+DEPLOYED_API_ENVIRONMENT = {"FACULTY_SERVER_TYPE": "prod-python-api"}
+TEST_API_ENVIRONMENT = {"FACULTY_SERVER_TYPE": "dev-python-api"}
 
 ALL_ENVIRONMENT_EMPTY_STRING = {
     key: "" for key in merge_dicts(STANDARD_ENVIRONMENT, JOB_ENVIRONMENT)
@@ -75,6 +78,15 @@ JOB_TAGS = {
     "mlflow.faculty.job.subrunId": "subrun-id",
     "mlflow.faculty.job.subrunNumber": "2",
 }
+APP_TAGS = {"mlflow.faculty.createdBy": "app"}
+DEPLOYED_API_TAGS = {
+    "mlflow.faculty.createdBy": "api",
+    "mlflow.faculty.api.mode": "deploy",
+}
+TEST_API_TAGS = {
+    "mlflow.faculty.createdBy": "api",
+    "mlflow.faculty.api.mode": "test",
+}
 
 
 @pytest.mark.parametrize(
@@ -98,10 +110,30 @@ def test_in_context(mocker, env, in_context):
             merge_dicts(STANDARD_ENVIRONMENT, JOB_ENVIRONMENT),
             merge_dicts(STANDARD_TAGS, JOB_TAGS),
         ),
+        (
+            merge_dicts(STANDARD_ENVIRONMENT, APP_ENVIRONMENT),
+            merge_dicts(STANDARD_TAGS, APP_TAGS),
+        ),
+        (
+            merge_dicts(STANDARD_ENVIRONMENT, DEPLOYED_API_ENVIRONMENT),
+            merge_dicts(STANDARD_TAGS, DEPLOYED_API_TAGS),
+        ),
+        (
+            merge_dicts(STANDARD_ENVIRONMENT, TEST_API_ENVIRONMENT),
+            merge_dicts(STANDARD_TAGS, TEST_API_TAGS),
+        ),
         ({}, {}),
         (ALL_ENVIRONMENT_EMPTY_STRING, {}),
     ],
-    ids=["standard", "job", "no-env", "env-empty-string"],
+    ids=[
+        "standard",
+        "job",
+        "app",
+        "deployed-api",
+        "test-api",
+        "no-env",
+        "env-empty-string",
+    ],
 )
 @pytest.mark.parametrize(
     "account_available, user_tags",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -33,11 +33,13 @@ STANDARD_ENVIRONMENT = {
     "FACULTY_PROJECT_ID": "project-id",
     "FACULTY_SERVER_ID": "server-id",
     "FACULTY_SERVER_NAME": "server-name",
+    "FACULTY_SERVER_TYPE": "jupyter",
     "NUM_CPUS": "4",
     "AVAILABLE_MEMORY_MB": "4000",
     "NUM_GPUS": "1",
 }
 JOB_ENVIRONMENT = {
+    "FACULTY_SERVER_TYPE": "python-job",
     "FACULTY_JOB_ID": "job-id",
     "FACULTY_JOB_NAME": "job-name",
     "FACULTY_RUN_ID": "run-id",
@@ -50,7 +52,9 @@ ALL_ENVIRONMENT_EMPTY_STRING = {
     key: "" for key in merge_dicts(STANDARD_ENVIRONMENT, JOB_ENVIRONMENT)
 }
 
+DEFAULT_TAGS = {"mlflow.faculty.createdBy": "user"}
 STANDARD_TAGS = {
+    "mlflow.faculty.createdBy": "user",
     "mlflow.faculty.project.projectId": "project-id",
     "mlflow.faculty.server.serverId": "server-id",
     "mlflow.faculty.server.name": "server-name",
@@ -63,6 +67,7 @@ USER_TAGS = {
     "mlflow.faculty.user.username": MOCK_ACCOUNT.username,
 }
 JOB_TAGS = {
+    "mlflow.faculty.createdBy": "job",
     "mlflow.faculty.job.jobId": "job-id",
     "mlflow.faculty.job.name": "job-name",
     "mlflow.faculty.job.runId": "run-id",
@@ -93,8 +98,8 @@ def test_in_context(mocker, env, in_context):
             merge_dicts(STANDARD_ENVIRONMENT, JOB_ENVIRONMENT),
             merge_dicts(STANDARD_TAGS, USER_TAGS, JOB_TAGS),
         ),
-        ({}, USER_TAGS),
-        (ALL_ENVIRONMENT_EMPTY_STRING, USER_TAGS),
+        ({}, merge_dicts(DEFAULT_TAGS, USER_TAGS)),
+        (ALL_ENVIRONMENT_EMPTY_STRING, merge_dicts(DEFAULT_TAGS, USER_TAGS)),
     ],
     ids=["standard", "job", "no-env", "env-empty-string"],
 )
@@ -116,8 +121,8 @@ def test_tags(mocker, environment, expected_tags):
             merge_dicts(STANDARD_ENVIRONMENT, JOB_ENVIRONMENT),
             merge_dicts(STANDARD_TAGS, JOB_TAGS),
         ),
-        ({}, {}),
-        (ALL_ENVIRONMENT_EMPTY_STRING, {}),
+        ({}, DEFAULT_TAGS),
+        (ALL_ENVIRONMENT_EMPTY_STRING, DEFAULT_TAGS),
     ],
     ids=["standard", "job", "no-env", "env-empty-string"],
 )

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -47,9 +47,15 @@ JOB_ENVIRONMENT = {
     "FACULTY_SUBRUN_ID": "subrun-id",
     "FACULTY_SUBRUN_NUMBER": "2",
 }
-APP_ENVIRONMENT = {"FACULTY_SERVER_TYPE": "app"}
-DEPLOYED_API_ENVIRONMENT = {"FACULTY_SERVER_TYPE": "prod-python-api"}
-TEST_API_ENVIRONMENT = {"FACULTY_SERVER_TYPE": "dev-python-api"}
+APP_ENVIRONMENT = {"FACULTY_SERVER_TYPE": "app", "FACULTY_APP_ID": "app-id"}
+DEPLOYED_API_ENVIRONMENT = {
+    "FACULTY_SERVER_TYPE": "prod-python-api",
+    "FACULTY_API_ID": "api-id",
+}
+TEST_API_ENVIRONMENT = {
+    "FACULTY_SERVER_TYPE": "dev-python-api",
+    "FACULTY_API_ID": "api-id",
+}
 
 ALL_ENVIRONMENT_EMPTY_STRING = {
     key: "" for key in merge_dicts(STANDARD_ENVIRONMENT, JOB_ENVIRONMENT)
@@ -78,13 +84,18 @@ JOB_TAGS = {
     "mlflow.faculty.job.subrunId": "subrun-id",
     "mlflow.faculty.job.subrunNumber": "2",
 }
-APP_TAGS = {"mlflow.faculty.createdBy": "app"}
+APP_TAGS = {
+    "mlflow.faculty.createdBy": "app",
+    "mlflow.faculty.app.appId": "app-id",
+}
 DEPLOYED_API_TAGS = {
     "mlflow.faculty.createdBy": "api",
+    "mlflow.faculty.api.apiId": "api-id",
     "mlflow.faculty.api.mode": "deploy",
 }
 TEST_API_TAGS = {
     "mlflow.faculty.createdBy": "api",
+    "mlflow.faculty.api.apiId": "api-id",
     "mlflow.faculty.api.mode": "test",
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ passenv = AWS_*
 deps =
     pytest
     pytest-mock
-    mock
     pytz
 commands = pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ passenv = AWS_*
 deps =
     pytest
     pytest-mock
+    mock
     pytz
 commands = pytest {posargs}
 


### PR DESCRIPTION
This hooks into MLflow, providing Faculty-specific tags when available.

While developing this, I've discovered an issue with a circular import. As a result, I've made the `FacultyRunContext` not inherit from the MLflow `RunContextProvider` abstract base class to avoid the circular import. I intend to open a PR with MLflow to correct this, but I don't expect it to get in the current release.