### PR TITLE
Fix test by adding a new required run_number field

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -70,12 +70,14 @@ FACULTY_EXPERIMENT = FacultyExperiment(
 
 RUN_UUID = uuid4()
 RUN_UUID_HEX_STR = RUN_UUID.hex
+RUN_NUMBER = 42
 
 RUN_STARTED_AT = datetime(2018, 3, 10, 11, 39, 12, 110000, tzinfo=UTC)
 RUN_STARTED_AT_MILLISECONDS = to_timestamp(RUN_STARTED_AT) * 1000
 
 FACULTY_RUN = ExperimentRun(
     id=RUN_UUID,
+    run_number=RUN_NUMBER,
     experiment_id=FACULTY_EXPERIMENT.id,
     artifact_location=ARTIFACT_LOCATION,
     status=ExperimentRunStatus.RUNNING,


### PR DESCRIPTION
This PR fixes tests that will fail when https://github.com/facultyai/faculty/pull/85 gets merged.

As discusses, run numbers are faculty-specific, so they won't be surfaced to the mlflow model.