### PR TITLE
Fix log_batch and add log_{param,metric} and set_tag methods

### DIFF
--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -326,3 +326,6 @@ class FacultyRestStore(AbstractStore):
             )
         except faculty.clients.base.HttpError as e:
             raise faculty_http_error_to_mlflow_exception(e)
+
+    def log_metric(self, run_id, metric):
+        return self.log_batch(run_id, metrics=[metric])

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -329,3 +329,6 @@ class FacultyRestStore(AbstractStore):
 
     def log_metric(self, run_id, metric):
         return self.log_batch(run_id, metrics=[metric])
+
+    def log_param(self, run_id, param):
+        return self.log_batch(run_id, params=[param])

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -328,10 +328,34 @@ class FacultyRestStore(AbstractStore):
             raise faculty_http_error_to_mlflow_exception(e)
 
     def log_metric(self, run_id, metric):
+        """
+        Log a metric for the specified run
+
+        :param run_uuid: String id for the run
+        :param metric: :py:class:`mlflow.entities.Metric` instance to log
+        """
+        # TODO: Remove this method once the functionality is moved
+        # into the abstract store in mlflow.
         return self.log_batch(run_id, metrics=[metric])
 
     def log_param(self, run_id, param):
+        """
+        Log a param for the specified run
+
+        :param run_uuid: String id for the run
+        :param param: :py:class:`mlflow.entities.Param` instance to log
+        """
+        # TODO: Remove this method once the functionality is moved
+        # into the abstract store in mlflow.
         return self.log_batch(run_id, params=[param])
 
     def set_tag(self, run_id, tag):
+        """
+        Set a tag for the specified run
+
+        :param run_uuid: String id for the run
+        :param tag: :py:class:`mlflow.entities.RunTag` instance to set
+        """
+        # TODO: Remove this method once the functionality is moved
+        # into the abstract store in mlflow.
         return self.log_batch(run_id, tags=[tag])

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -291,7 +291,7 @@ class FacultyRestStore(AbstractStore):
         else:
             return [faculty_run_to_mlflow_run(run) for run in faculty_runs]
 
-    def log_batch(self, run_uuid, metrics=None, params=None, tags=None):
+    def log_batch(self, run_id, metrics=None, params=None, tags=None):
         """
         Fetches the experiment by ID from the backend store.
 
@@ -308,7 +308,7 @@ class FacultyRestStore(AbstractStore):
         try:
             self._client.log_run_data(
                 self._project_id,
-                UUID(run_uuid),
+                UUID(run_id),
                 params=[
                     mlflow_param_to_faculty_param(param) for param in params
                 ],

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -332,3 +332,6 @@ class FacultyRestStore(AbstractStore):
 
     def log_param(self, run_id, param):
         return self.log_batch(run_id, params=[param])
+
+    def set_tag(self, run_id, tag):
+        return self.log_batch(run_id, tags=[tag])

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -524,7 +524,7 @@ def test_log_batch(mocker):
 
     store = FacultyRestStore(STORE_URI)
     store.log_batch(
-        RUN_UUID_HEX_STR,
+        run_id=RUN_UUID_HEX_STR,
         metrics=[MLFLOW_METRIC],
         params=[MLFLOW_PARAM],
         tags=[MLFLOW_TAG],

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -640,6 +640,26 @@ def test_log_param(mocker):
     param_converter_mock.assert_called_once_with(MLFLOW_PARAM)
 
 
+def test_set_tag(mocker):
+    mock_client = mocker.Mock()
+    mocker.patch("faculty.client", return_value=mock_client)
+    mlflow_tag = mocker.Mock()
+    tag_converter_mock = mocker.patch(
+        "mlflow_faculty.trackingstore.mlflow_tag_to_faculty_tag",
+        return_value=mlflow_tag
+    )
+    store = FacultyRestStore(STORE_URI)
+    store.set_tag(RUN_UUID_HEX_STR, MLFLOW_TAG)
+    mock_client.log_run_data.assert_called_once_with(
+        PROJECT_ID,
+        RUN_UUID,
+        metrics=[],
+        params=[],
+        tags=[mlflow_tag]
+    )
+    tag_converter_mock.assert_called_once_with(MLFLOW_TAG)
+
+
 def test_delete_experiment(mocker):
     mock_client = mocker.Mock()
     mocker.patch("faculty.client", return_value=mock_client)

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -594,6 +594,29 @@ def test_log_batch_error(mocker):
     )
 
 
+def test_log_metric(mocker):
+    mock_client = mocker.Mock()
+    mocker.patch("faculty.client", return_value=mock_client)
+    mlflow_metric = mocker.Mock()
+    metric_converter_mock = mocker.patch(
+        "mlflow_faculty.trackingstore.mlflow_metric_to_faculty_metric",
+        return_value=mlflow_metric,
+    )
+    store = FacultyRestStore(STORE_URI)
+    store.log_metric(
+        RUN_UUID_HEX_STR,
+        MLFLOW_METRIC
+    )
+    mock_client.log_run_data.assert_called_once_with(
+        PROJECT_ID,
+        RUN_UUID,
+        metrics=[mlflow_metric],
+        params=[],
+        tags=[]
+    )
+    metric_converter_mock.assert_called_once_with(MLFLOW_METRIC)
+
+
 def test_delete_experiment(mocker):
     mock_client = mocker.Mock()
     mocker.patch("faculty.client", return_value=mock_client)

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -617,6 +617,29 @@ def test_log_metric(mocker):
     metric_converter_mock.assert_called_once_with(MLFLOW_METRIC)
 
 
+def test_log_param(mocker):
+    mock_client = mocker.Mock()
+    mocker.patch("faculty.client", return_value=mock_client)
+    mlflow_param = mocker.Mock()
+    param_converter_mock = mocker.patch(
+        "mlflow_faculty.trackingstore.mlflow_param_to_faculty_param",
+        return_value=mlflow_param,
+    )
+    store = FacultyRestStore(STORE_URI)
+    store.log_param(
+        RUN_UUID_HEX_STR,
+        MLFLOW_PARAM
+    )
+    mock_client.log_run_data.assert_called_once_with(
+        PROJECT_ID,
+        RUN_UUID,
+        metrics=[],
+        params=[mlflow_param],
+        tags=[]
+    )
+    param_converter_mock.assert_called_once_with(MLFLOW_PARAM)
+
+
 def test_delete_experiment(mocker):
     mock_client = mocker.Mock()
     mocker.patch("faculty.client", return_value=mock_client)

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -603,16 +603,9 @@ def test_log_metric(mocker):
         return_value=mlflow_metric,
     )
     store = FacultyRestStore(STORE_URI)
-    store.log_metric(
-        RUN_UUID_HEX_STR,
-        MLFLOW_METRIC
-    )
+    store.log_metric(RUN_UUID_HEX_STR, MLFLOW_METRIC)
     mock_client.log_run_data.assert_called_once_with(
-        PROJECT_ID,
-        RUN_UUID,
-        metrics=[mlflow_metric],
-        params=[],
-        tags=[]
+        PROJECT_ID, RUN_UUID, metrics=[mlflow_metric], params=[], tags=[]
     )
     metric_converter_mock.assert_called_once_with(MLFLOW_METRIC)
 
@@ -626,16 +619,9 @@ def test_log_param(mocker):
         return_value=mlflow_param,
     )
     store = FacultyRestStore(STORE_URI)
-    store.log_param(
-        RUN_UUID_HEX_STR,
-        MLFLOW_PARAM
-    )
+    store.log_param(RUN_UUID_HEX_STR, MLFLOW_PARAM)
     mock_client.log_run_data.assert_called_once_with(
-        PROJECT_ID,
-        RUN_UUID,
-        metrics=[],
-        params=[mlflow_param],
-        tags=[]
+        PROJECT_ID, RUN_UUID, metrics=[], params=[mlflow_param], tags=[]
     )
     param_converter_mock.assert_called_once_with(MLFLOW_PARAM)
 
@@ -646,16 +632,12 @@ def test_set_tag(mocker):
     mlflow_tag = mocker.Mock()
     tag_converter_mock = mocker.patch(
         "mlflow_faculty.trackingstore.mlflow_tag_to_faculty_tag",
-        return_value=mlflow_tag
+        return_value=mlflow_tag,
     )
     store = FacultyRestStore(STORE_URI)
     store.set_tag(RUN_UUID_HEX_STR, MLFLOW_TAG)
     mock_client.log_run_data.assert_called_once_with(
-        PROJECT_ID,
-        RUN_UUID,
-        metrics=[],
-        params=[],
-        tags=[mlflow_tag]
+        PROJECT_ID, RUN_UUID, metrics=[], params=[], tags=[mlflow_tag]
     )
     tag_converter_mock.assert_called_once_with(MLFLOW_TAG)
 


### PR DESCRIPTION
Prior to this PR, `mlflow.log_param`, `mlflow.log_metric` and `mlflow.set_tag` were no-ops because they just inherited from the abstract store. This PR implements them by proxying to the `log_batch` method.

Separately, the `log_metrics` failed because the `log_batch` endpoint use `run_uuid` as the kwarg instead of `run_id`.