### PR TITLE
Fail updating on deleted experiment

### DIFF
--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -19,6 +19,10 @@ from six.moves import urllib
 import faculty
 import faculty.clients.base
 import faculty.clients.experiment
+from faculty.clients.experiment import (
+    ParamConflict as FacultyParamConflict,
+    ExperimentNotActiveConflict as FacultyExperimentNotActiveConflict,
+)
 from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.store.abstract_store import AbstractStore
@@ -394,13 +398,13 @@ class FacultyRestStore(AbstractStore):
                 ],
                 tags=[mlflow_tag_to_faculty_tag(tag) for tag in tags],
             )
-        except faculty.clients.experiment.ParamConflict as conflict:
+        except FacultyParamConflict as conflict:
             raise MlflowException(
                 "Conflicting param keys: {}".format(
                     conflict.conflicting_params
                 )
             )
-        except faculty.clients.experiment.ExperimentNotActiveConflict as conflict:
+        except FacultyExperimentNotActiveConflict as conflict:
             raise MlflowException(
                 "Non active experiment with id: {}".format(
                     conflict.experiment_id

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -21,7 +21,7 @@ import faculty.clients.base
 import faculty.clients.experiment
 from faculty.clients.experiment import (
     ParamConflict as FacultyParamConflict,
-    ExperimentNotActiveConflict as FacultyExperimentNotActiveConflict,
+    ExperimentDeleted as FacultyExperimentDeleted,
 )
 from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
@@ -262,10 +262,16 @@ class FacultyRestStore(AbstractStore):
                 None if parent_run_id is None else UUID(parent_run_id),
                 tags=[mlflow_tag_to_faculty_tag(tag) for tag in tags],
             )
-        except FacultyExperimentNotActiveConflict as conflict:
+        except FacultyExperimentDeleted as conflict:
             raise MlflowException(
-                "Non active experiment with id: {}".format(
-                    conflict.experiment_id
+                # "Non active experiment with id: {}".format(
+                #     conflict.experiment_id
+                # )
+                "Experiment {} is deleted."
+                " To create runs for this experiment,"
+                " first restore it with the shell command "
+                "'mlflow experiments restore {}'".format(
+                    conflict.experiment_id, conflict.experiment_id
                 )
             )
         except faculty.clients.base.HttpError as e:

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -264,14 +264,11 @@ class FacultyRestStore(AbstractStore):
             )
         except FacultyExperimentDeleted as conflict:
             raise MlflowException(
-                # "Non active experiment with id: {}".format(
-                #     conflict.experiment_id
-                # )
-                "Experiment {} is deleted."
+                "Experiment {0} is deleted."
                 " To create runs for this experiment,"
                 " first restore it with the shell command "
-                "'mlflow experiments restore {}'".format(
-                    conflict.experiment_id, conflict.experiment_id
+                "'mlflow experiments restore {0}'".format(
+                    conflict.experiment_id
                 )
             )
         except faculty.clients.base.HttpError as e:

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -400,6 +400,12 @@ class FacultyRestStore(AbstractStore):
                     conflict.conflicting_params
                 )
             )
+        except faculty.clients.experiment.ExperimentNotActiveConflict as conflict:
+            raise MlflowException(
+                "Non active experiment with id: {}".format(
+                    conflict.experiment_id
+                )
+            )
         except faculty.clients.base.HttpError as e:
             raise faculty_http_error_to_mlflow_exception(e)
 

--- a/mlflow_faculty/trackingstore.py
+++ b/mlflow_faculty/trackingstore.py
@@ -262,6 +262,12 @@ class FacultyRestStore(AbstractStore):
                 None if parent_run_id is None else UUID(parent_run_id),
                 tags=[mlflow_tag_to_faculty_tag(tag) for tag in tags],
             )
+        except FacultyExperimentNotActiveConflict as conflict:
+            raise MlflowException(
+                "Non active experiment with id: {}".format(
+                    conflict.experiment_id
+                )
+            )
         except faculty.clients.base.HttpError as e:
             raise faculty_http_error_to_mlflow_exception(e)
         else:
@@ -402,12 +408,6 @@ class FacultyRestStore(AbstractStore):
             raise MlflowException(
                 "Conflicting param keys: {}".format(
                     conflict.conflicting_params
-                )
-            )
-        except FacultyExperimentNotActiveConflict as conflict:
-            raise MlflowException(
-                "Non active experiment with id: {}".format(
-                    conflict.experiment_id
                 )
             )
         except faculty.clients.base.HttpError as e:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(),
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
-    install_requires=["mlflow>=0.9.0", "faculty>=0.23.0", "six", "pytz"],
+    install_requires=["mlflow>=0.9.0", "faculty>=0.23.2", "six", "pytz"],
     entry_points={
         "mlflow.tracking_store": TRACKING_STORE_ENTRYPOINT,
         "mlflow.artifact_repository": ARTIFACT_REPOSITORY_ENTRYPOINT,

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -330,7 +330,7 @@ def test_create_run(mocker, mlflow_parent_run_id, faculty_parent_run_id):
     assert returned_run == mlflow_run
 
 
-def test_create_run_experiment_not_active_conflict(mocker):
+def test_create_run_experiment_deleted(mocker):
     mlflow_timestamp = mocker.Mock()
     faculty_datetime = mocker.Mock()
     timestamp_converter_mock = mocker.patch(
@@ -347,7 +347,7 @@ def test_create_run_experiment_not_active_conflict(mocker):
     )
 
     mock_client = mocker.Mock()
-    exception = faculty.clients.experiment.ExperimentNotActiveConflict(
+    exception = faculty.clients.experiment.ExperimentDeleted(
         message="message", experiment_id="test-id"
     )
 
@@ -359,22 +359,18 @@ def test_create_run_experiment_not_active_conflict(mocker):
     store = FacultyRestStore(STORE_URI)
 
     with pytest.raises(MlflowException, match="experiment"):
-        with pytest.raises(
-            faculty.clients.experiment.ExperimentNotActiveConflict,
-            match="message",
-        ):
-            store.create_run(
-                experiment_id,
-                "unused-mlflow-user-id",
-                run_name,
-                "unused-source-type",
-                "unused-source-name",
-                "unused-entry-point-name",
-                mlflow_timestamp,
-                "unused-source-version",
-                [mlflow_tag],
-                PARENT_RUN_UUID_HEX_STR,
-            )
+        store.create_run(
+            experiment_id,
+            "unused-mlflow-user-id",
+            run_name,
+            "unused-source-type",
+            "unused-source-name",
+            "unused-entry-point-name",
+            mlflow_timestamp,
+            "unused-source-version",
+            [mlflow_tag],
+            PARENT_RUN_UUID_HEX_STR,
+        )
 
     timestamp_converter_mock.assert_called_once_with(mlflow_timestamp)
     tag_converter_mock.assert_called_once_with(mlflow_tag)

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -906,10 +906,7 @@ def test_log_batch_param_conflict(mocker):
     store = FacultyRestStore(STORE_URI)
 
     with pytest.raises(MlflowException, match="param-key"):
-        with pytest.raises(
-            faculty.clients.experiment.ParamConflict, match="message"
-        ):
-            store.log_batch(RUN_UUID_HEX_STR)
+        store.log_batch(RUN_UUID_HEX_STR)
     mock_client.log_run_data.assert_called_once_with(
         PROJECT_ID, RUN_UUID, metrics=[], params=[], tags=[]
     )
@@ -927,8 +924,7 @@ def test_log_batch_error(mocker):
     store = FacultyRestStore(STORE_URI)
 
     with pytest.raises(MlflowException, match="error_message"):
-        with pytest.raises(HttpError, match="some_error_code"):
-            store.log_batch(RUN_UUID_HEX_STR)
+        store.log_batch(RUN_UUID_HEX_STR)
     mock_client.log_run_data.assert_called_once_with(
         PROJECT_ID, RUN_UUID, metrics=[], params=[], tags=[]
     )

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -861,6 +861,28 @@ def test_log_batch_param_conflict(mocker):
     )
 
 
+def test_log_batch_experiment_not_active_conflict(mocker):
+    mock_client = mocker.Mock()
+    exception = faculty.clients.experiment.ExperimentNotActiveConflict(
+        message="message", experiment_id="test-id"
+    )
+
+    mock_client.log_run_data.side_effect = exception
+    mocker.patch("faculty.client", return_value=mock_client)
+
+    store = FacultyRestStore(STORE_URI)
+
+    with pytest.raises(MlflowException, match="experiment"):
+        with pytest.raises(
+            faculty.clients.experiment.ExperimentNotActiveConflict,
+            match="message",
+        ):
+            store.log_batch(RUN_UUID_HEX_STR)
+    mock_client.log_run_data.assert_called_once_with(
+        PROJECT_ID, RUN_UUID, metrics=[], params=[], tags=[]
+    )
+
+
 def test_log_batch_error(mocker):
     mock_client = mocker.Mock()
     exception = HttpError(

--- a/tests/test_trackingstore.py
+++ b/tests/test_trackingstore.py
@@ -332,26 +332,24 @@ def test_create_run(mocker, mlflow_parent_run_id, faculty_parent_run_id):
 
 def test_create_run_experiment_deleted(mocker):
     mlflow_timestamp = mocker.Mock()
-    faculty_datetime = mocker.Mock()
-    timestamp_converter_mock = mocker.patch(
+    mocker.patch(
         "mlflow_faculty.trackingstore."
         "mlflow_timestamp_to_datetime_milliseconds",
-        return_value=faculty_datetime,
+        return_value=mocker.Mock(),
     )
 
     mlflow_tag = mocker.Mock()
-    faculty_tag = mocker.Mock()
-    tag_converter_mock = mocker.patch(
+    mocker.patch(
         "mlflow_faculty.trackingstore.mlflow_tag_to_faculty_tag",
-        return_value=faculty_tag,
+        return_value=mocker.Mock(),
     )
 
     mock_client = mocker.Mock()
     exception = faculty.clients.experiment.ExperimentDeleted(
         message="message", experiment_id="test-id"
     )
-
     mock_client.create_run.side_effect = exception
+
     mocker.patch("faculty.client", return_value=mock_client)
     experiment_id = mocker.Mock()
     run_name = mocker.Mock()
@@ -371,17 +369,6 @@ def test_create_run_experiment_deleted(mocker):
             [mlflow_tag],
             PARENT_RUN_UUID_HEX_STR,
         )
-
-    timestamp_converter_mock.assert_called_once_with(mlflow_timestamp)
-    tag_converter_mock.assert_called_once_with(mlflow_tag)
-    mock_client.create_run.assert_called_once_with(
-        PROJECT_ID,
-        experiment_id,
-        run_name,
-        faculty_datetime,
-        PARENT_RUN_UUID,
-        tags=[faculty_tag],
-    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR handles the faculty library raising an `ExperimentNotActiveConflict` exception on run creation. This depends on changes introduced in https://github.com/facultyai/faculty/pull/96