### PR TITLE
Update minimum version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(),
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
-    install_requires=["mlflow>=1.0.0", "faculty>=0.23.2", "six", "pytz"],
+    install_requires=["mlflow>=1.0.0", "faculty>=0.24.0", "six", "pytz"],
     entry_points={
         "mlflow.tracking_store": TRACKING_STORE_ENTRYPOINT,
         "mlflow.artifact_repository": ARTIFACT_REPOSITORY_ENTRYPOINT,


### PR DESCRIPTION
Currently, installations with faculty<0.24 as a value in the `ExperimentRunStatus` enum is missing. This PR changes the minimum version requirement to reflect that.