### PR TITLE
Support MLflow filter strings

### DIFF
--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -14,6 +14,7 @@ from sqlparse.tokens import Token as SqlTokenType
 from faculty.clients.experiment import (
     ComparisonOperator,
     CompoundFilter,
+    DeletedAtFilter,
     ExperimentIdFilter,
     ExperimentRunStatus,
     LogicalOperator,
@@ -23,6 +24,7 @@ from faculty.clients.experiment import (
     RunStatusFilter,
     TagFilter,
 )
+from mlflow.entities import ViewType
 
 INVALID_IDENTIFIER_TPL = (
     "Invalid identifier {!r}. Expected identifier of format "
@@ -77,6 +79,27 @@ def filter_by_experiment_id(experiment_ids):
         return parts[0]
     else:
         return CompoundFilter(LogicalOperator.OR, parts)
+
+
+def filter_by_mlflow_view_type(view_type):
+    """Build a filter for an MLflow view type.
+
+    Parameters
+    ----------
+    view_type : mlflow.entities.ViewType
+
+    Returns
+    -------
+    A Faculty library filter object, or None if no filter is to be applied.
+    """
+    if view_type == ViewType.ACTIVE_ONLY:
+        return DeletedAtFilter(ComparisonOperator.DEFINED, False)
+    elif view_type == ViewType.DELETED_ONLY:
+        return DeletedAtFilter(ComparisonOperator.DEFINED, True)
+    elif view_type == ViewType.ALL:
+        return None
+    else:
+        raise ValueError("Invalid ViewType: {}".format(view_type))
 
 
 def parse_filter_string(mlflow_filter_string):

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -364,7 +364,7 @@ def _extract_string(token):
 
 
 def _extract_number_or_string(token):
-    #  Number takes priority
+    # Number takes priority
     try:
         return _extract_number(token)
     except ValueError:

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -1,0 +1,370 @@
+from enum import Enum
+from uuid import UUID
+
+import sqlparse
+from sqlparse.sql import (
+    Comparison as SqlComparison,
+    Identifier as SqlIdentifier,
+    Statement as SqlStatement,
+    Parenthesis as SqlParenthesis,
+)
+from sqlparse.tokens import Token as SqlTokenType
+
+
+from faculty.clients.experiment import (
+    ComparisonOperator,
+    CompoundFilter,
+    ExperimentRunStatus,
+    LogicalOperator,
+    MetricFilter,
+    ParamFilter,
+    RunIdFilter,
+    RunStatusFilter,
+    TagFilter,
+)
+
+STRING_VALUE_SQL_TYPES = {SqlTokenType.Literal.String.Single}
+NUMERIC_VALUE_SQL_TYPES = {
+    SqlTokenType.Literal.Number.Integer,
+    SqlTokenType.Literal.Number.Float,
+}
+
+INVALID_IDENTIFIER_TPL = (
+    "Expected param, metric or tag identifier of format "
+    "'metric.<key> <comparator> <value>', 'tag.<key> <comparator> <value>', "
+    "or 'params.<key> <comparator> <value>' but found '{token}'."
+)
+INVALID_OPERATOR_TPL = "'{token}' is not a valid operator."
+
+
+class _KeyType(Enum):
+    RUN_ID = "run ID"
+    STATUS = "status"
+    PARAM = "parameter"
+    METRIC = "metric"
+    TAG = "tag"
+
+
+ATTRIBUTE_IDENTIFIERS = {"attribute", "attributes", "attr", "run"}
+RUN_ID_IDENTIFIERS = {"id", "run_id", "runId"}
+PARAM_IDENTIFIERS = {"param", "params", "parameter", "parameters"}
+METRIC_IDENTIFIERS = {"metric", "metrics"}
+TAG_IDENTIFIERS = {"tag", "tags"}
+
+COMPARISON_OPERATOR_MAPPING = {
+    "=": ComparisonOperator.EQUAL_TO,
+    "!=": ComparisonOperator.NOT_EQUAL_TO,
+    ">": ComparisonOperator.GREATER_THAN,
+    ">=": ComparisonOperator.GREATER_THAN_OR_EQUAL_TO,
+    "<": ComparisonOperator.LESS_THAN,
+    "<=": ComparisonOperator.LESS_THAN_OR_EQUAL_TO,
+}
+DISCRETE_KEY_TYPES = {_KeyType.RUN_ID, _KeyType.STATUS, _KeyType.TAG}
+DISCRETE_OPERATORS = {
+    ComparisonOperator.DEFINED,
+    ComparisonOperator.EQUAL_TO,
+    ComparisonOperator.NOT_EQUAL_TO,
+}
+
+
+# class ComparisonOperator(Enum):
+#     DEFINED = "defined"
+#     EQUAL_TO = "eq"
+#     NOT_EQUAL_TO = "ne"
+#     LESS_THAN = "lt"
+#     LESS_THAN_OR_EQUAL_TO = "le"
+#     GREATER_THAN = "gt"
+#     GREATER_THAN_OR_EQUAL_TO = "ge"
+
+
+# ProjectIdFilter = namedtuple("ProjectIdFilter", ["operator", "value"])
+# ExperimentIdFilter = namedtuple("ExperimentIdFilter", ["operator", "value"])
+# RunIdFilter = namedtuple("RunIdFilter", ["operator", "value"])
+# DeletedAtFilter = namedtuple("DeletedAtFilter", ["operator", "value"])
+# TagFilter = namedtuple("TagFilter", ["key", "operator", "value"])
+# ParamFilter = namedtuple("ParamFilter", ["key", "operator", "value"])
+# MetricFilter = namedtuple("MetricFilter", ["key", "operator", "value"])
+
+
+# class LogicalOperator(Enum):
+#     AND = "and"
+#     OR = "or"
+
+
+# CompoundFilter = namedtuple("CompoundFilter", ["operator", "conditions"])
+
+
+def parse_filter_string(mlflow_filter_string):
+    """Parse an MLflow filter string into a Faculty filter object."""
+    try:
+        parsed = sqlparse.parse(mlflow_filter_string)
+    except Exception:
+        raise ValueError(
+            "Error parsing filter '{}'".format(mlflow_filter_string)
+        )
+
+    try:
+        [statement] = parsed
+    except ValueError:
+        raise ValueError(
+            "Invalid filter '{}'. Must be a single statement.".format(
+                mlflow_filter_string
+            )
+        )
+
+    if not isinstance(statement, SqlStatement):
+        raise ValueError(
+            "Invalid filter '{}'. Must be a single statement.".format(
+                mlflow_filter_string
+            )
+        )
+
+    return _parse_token_list(statement.tokens)
+
+
+def _is_and(token):
+    return token.match(ttype=SqlTokenType.Keyword, values=["AND"])
+
+
+def _is_or(token):
+    return token.match(ttype=SqlTokenType.Keyword, values=["AND"])
+
+
+def _split_list(source_list, condition):
+    chunk = []
+    for value in source_list:
+        if condition(value):
+            yield chunk
+            chunk = []
+        else:
+            chunk.append(value)
+    yield chunk
+
+
+def _parse_token_list(tokens):
+    """Parse a list of sqlparse Tokens and return an equivalent filter."""
+
+    # Ignore whitespace chars
+    tokens = [t for t in tokens if not t.is_whitespace]
+
+    if any(_is_or(t) for t in tokens):
+        filters = []
+        for part in _split_list(tokens, _is_or):
+            filters.append(_parse_token_list(part))
+        return CompoundFilter(LogicalOperator.OR, filters)
+
+    elif any(_is_and(t) for t in tokens):
+        filters = []
+        for part in _split_list(tokens, _is_and):
+            filters.append(_parse_token_list(part))
+        return CompoundFilter(LogicalOperator.AND, filters)
+
+    elif len(tokens) == 1:
+        [token] = tokens
+        if isinstance(token, SqlParenthesis):
+            # Strip opening and closing parentheses
+            return _parse_token_list(token.tokens[1:-1])
+        elif isinstance(token, SqlComparison):
+            return _parse_token_list(token.tokens)
+        else:
+            raise ValueError(
+                "Unsupported filter string component: {!r}".format(
+                    token.normalized
+                )
+            )
+
+    elif len(tokens) == 3:
+        return _single_filter_from_tokens(*tokens)
+
+    else:
+        raise ValueError(
+            "Unsupported filter string component: {!r}".format(
+                " ".join(t.normalized for t in tokens)
+            )
+        )
+
+
+def _validate_operator(key_type, operator, value):
+    if key_type in DISCRETE_KEY_TYPES:
+        if operator not in DISCRETE_OPERATORS:
+            raise ValueError(
+                "{} filters can only be used with operators '=', '!=' and "
+                "'IS NULL'".format(key_type.value.capitalize())
+            )
+    elif key_type == _KeyType.PARAM and isinstance(value, str):
+        if operator not in DISCRETE_OPERATORS:
+            raise ValueError(
+                "Param filters with string values can only be used with "
+                "operators '=', '!=' and 'IS NULL'"
+            )
+
+
+def _single_filter_from_tokens(identifier_token, operator_token, value_token):
+    key_type, key = _parse_identifier(identifier_token)
+    operator = _parse_operator(operator_token)
+
+    if operator == ComparisonOperator.DEFINED:
+        value = _extract_defined(value_token)
+    elif key_type == _KeyType.RUN_ID:
+        value_string = _extract_string(value_token)
+        try:
+            value = UUID(value_string)
+        except ValueError:
+            raise ValueError("{!r} is not a valid UUID".format(value_string))
+    elif key_type == _KeyType.STATUS:
+        value_string = _extract_string(value_token)
+        try:
+            value = ExperimentRunStatus(value_string.lower())
+        except ValueError:
+            raise ValueError(
+                "{!r} is not a valid run status".format(value_string)
+            )
+    elif key_type == _KeyType.PARAM:
+        value = _extract_number_or_string(value_token)
+    elif key_type == _KeyType.METRIC:
+        value = _extract_number(value_token)
+    elif key_type == _KeyType.TAG:
+        value = _extract_string(value_token)
+
+    _validate_operator(key_type, operator, value)
+
+    if key_type == _KeyType.RUN_ID:
+        return RunIdFilter(operator, value)
+    elif key_type == _KeyType.STATUS:
+        return RunStatusFilter(operator, value)
+    elif key_type == _KeyType.PARAM:
+        return ParamFilter(key, operator, value)
+    elif key_type == _KeyType.METRIC:
+        return MetricFilter(key, operator, value)
+    elif key_type == _KeyType.TAG:
+        return TagFilter(key, operator, value)
+    else:
+        raise Exception("Unexpected key_type")
+
+
+def _parse_identifier(token):
+    if not isinstance(token, SqlIdentifier):
+        raise ValueError(INVALID_IDENTIFIER_TPL.format(token=token.value))
+
+    try:
+        key_type_string, key = token.value.split(".", 1)
+    except ValueError:
+        raise ValueError(INVALID_IDENTIFIER_TPL.format(token=token.value))
+
+    key = _trim_backticks(_strip_quotes(key))
+
+    if key_type_string in ATTRIBUTE_IDENTIFIERS:
+        if key in RUN_ID_IDENTIFIERS:
+            return _KeyType.RUN_ID, None
+        elif key == "status":
+            return _KeyType.STATUS, None
+        else:
+            raise ValueError("Unsupported filter attribute '{}'".format(key))
+    elif key_type_string in PARAM_IDENTIFIERS:
+        return _KeyType.PARAM, key
+    elif key_type_string in METRIC_IDENTIFIERS:
+        return _KeyType.METRIC, key
+    elif key_type_string in TAG_IDENTIFIERS:
+        return _KeyType.TAG, key
+    else:
+        raise ValueError("Unsupported filter '{}'.".format(token.value))
+
+
+def _parse_operator(token):
+    if token.match(ttype=SqlTokenType.Keyword, values=["IS"]):
+        return ComparisonOperator.DEFINED
+    elif token.ttype == SqlTokenType.Operator.Comparison:
+        try:
+            return COMPARISON_OPERATOR_MAPPING[token.value]
+        except KeyError:
+            raise ValueError(INVALID_OPERATOR_TPL.format(token=token.value))
+    else:
+        raise ValueError(INVALID_OPERATOR_TPL.format(token=token.value))
+
+
+def _extract_defined(token):
+    if token.match(ttype=SqlTokenType.Keyword, values=["NULL"]):
+        return False
+    elif token.match(
+        ttype=SqlTokenType.Keyword, values=["NOT +NULL"], regex=True
+    ):
+        return True
+    else:
+        raise ValueError(
+            "Expected NULL or NOT NULL but found {!r}".format(token.value)
+        )
+
+
+def _extract_number(token):
+    if token.ttype in SqlTokenType.Literal.Number:
+        if token.ttype == SqlTokenType.Literal.Number.Integer:
+            return int(token.value)
+        else:
+            return float(token.value)
+    else:
+        raise ValueError(
+            "Expected a number but found {!r}".format(token.value)
+        )
+
+
+def _extract_string(token):
+    if token.ttype == SqlTokenType.Literal.String.Single or isinstance(
+        token, SqlIdentifier
+    ):
+        return _strip_quotes(token.value, require_quotes=True)
+    else:
+        raise ValueError(
+            "Expected a quoted string (e.g. 'my-value') "
+            "but found {!r}".format(token.value)
+        )
+
+
+def _extract_number_or_string(token):
+    #  Number takes priority
+    try:
+        return _extract_number(token)
+    except ValueError:
+        pass
+
+    try:
+        return _extract_string(token)
+    except ValueError:
+        # Don't raise new exception here to avoid linking it to the past one in
+        # Python 3
+        pass
+
+    raise ValueError(
+        "Expected a number or quoted string but found {!r}".format(token.value)
+    )
+
+
+def _strip_quotes(value, require_quotes=False):
+    if _is_quoted(value, "'") or _is_quoted(value, '"'):
+        return _trim_ends(value)
+    elif require_quotes:
+        raise ValueError(
+            "Parameter value is either not quoted or unidentified quote "
+            "types used for string {}. Use either single or double "
+            "quotes.".format(value)
+        )
+    else:
+        return value
+
+
+def _trim_backticks(entity_type):
+    """Remove backticks from identifier like `param`, if they exist."""
+    if _is_quoted(entity_type, "`"):
+        return _trim_ends(entity_type)
+    return entity_type
+
+
+def _is_quoted(value, pattern):
+    return (
+        len(value) >= 2
+        and value.startswith(pattern)
+        and value.endswith(pattern)
+    )
+
+
+def _trim_ends(string_value):
+    return string_value[1:-1]

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from uuid import UUID
 
+import six
 import sqlparse
 from sqlparse.sql import (
     Comparison as SqlComparison,
@@ -319,7 +320,7 @@ def _validate_operator(key_type, operator, value):
                 "{} filters can only be used with operators '=', '!=' and "
                 "'IS NULL'".format(key_type.value.capitalize())
             )
-    elif key_type == _KeyType.PARAM and isinstance(value, str):
+    elif key_type == _KeyType.PARAM and isinstance(value, six.string_types):
         if operator not in DISCRETE_OPERATORS:
             raise ValueError(
                 "Param filters with string values can only be used with "

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -67,33 +67,6 @@ DISCRETE_OPERATORS = {
 }
 
 
-# class ComparisonOperator(Enum):
-#     DEFINED = "defined"
-#     EQUAL_TO = "eq"
-#     NOT_EQUAL_TO = "ne"
-#     LESS_THAN = "lt"
-#     LESS_THAN_OR_EQUAL_TO = "le"
-#     GREATER_THAN = "gt"
-#     GREATER_THAN_OR_EQUAL_TO = "ge"
-
-
-# ProjectIdFilter = namedtuple("ProjectIdFilter", ["operator", "value"])
-# ExperimentIdFilter = namedtuple("ExperimentIdFilter", ["operator", "value"])
-# RunIdFilter = namedtuple("RunIdFilter", ["operator", "value"])
-# DeletedAtFilter = namedtuple("DeletedAtFilter", ["operator", "value"])
-# TagFilter = namedtuple("TagFilter", ["key", "operator", "value"])
-# ParamFilter = namedtuple("ParamFilter", ["key", "operator", "value"])
-# MetricFilter = namedtuple("MetricFilter", ["key", "operator", "value"])
-
-
-# class LogicalOperator(Enum):
-#     AND = "and"
-#     OR = "or"
-
-
-# CompoundFilter = namedtuple("CompoundFilter", ["operator", "conditions"])
-
-
 def parse_filter_string(mlflow_filter_string):
     """Parse an MLflow filter string into a Faculty filter object."""
     try:

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -240,11 +240,12 @@ def _single_filter_from_tokens(identifier_token, operator_token, value_token):
         try:
             value = ExperimentRunStatus(value_string.lower())
         except ValueError:
+            valid_statuses = {
+                status.value.upper() for status in ExperimentRunStatus
+            }
             raise ValueError(
                 INVALID_VALUE_TPL.format(
-                    "a run status (one of {})".format(
-                        set(status.value for status in ExperimentRunStatus)
-                    ),
+                    "a run status (one of {})".format(valid_statuses),
                     value_string,
                 )
             )

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -100,7 +100,7 @@ def _is_and(token):
 
 
 def _is_or(token):
-    return token.match(ttype=SqlTokenType.Keyword, values=["AND"])
+    return token.match(ttype=SqlTokenType.Keyword, values=["OR"])
 
 
 def _split_list(source_list, condition):

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -78,14 +78,14 @@ def build_search_runs_filter(experiment_ids, filter_string, view_type):
     filter_parts = []
 
     if experiment_ids is not None:
-        filter_parts.append(filter_by_experiment_id(experiment_ids))
+        filter_parts.append(_filter_by_experiment_id(experiment_ids))
 
-    deleted_at_filter = filter_by_mlflow_view_type(view_type)
+    deleted_at_filter = _filter_by_mlflow_view_type(view_type)
     if deleted_at_filter is not None:
         filter_parts.append(deleted_at_filter)
 
     if filter_string is not None and filter_string.strip() != "":
-        filter_parts.append(parse_filter_string(filter_string))
+        filter_parts.append(_parse_filter_string(filter_string))
 
     if len(filter_parts) == 0:
         return None
@@ -95,7 +95,7 @@ def build_search_runs_filter(experiment_ids, filter_string, view_type):
         return CompoundFilter(LogicalOperator.AND, filter_parts)
 
 
-def filter_by_experiment_id(experiment_ids):
+def _filter_by_experiment_id(experiment_ids):
     """Build a filter that a run is in one of a sequence of experiment IDs."""
 
     if len(experiment_ids) == 0:
@@ -113,7 +113,7 @@ def filter_by_experiment_id(experiment_ids):
         return CompoundFilter(LogicalOperator.OR, parts)
 
 
-def filter_by_mlflow_view_type(view_type):
+def _filter_by_mlflow_view_type(view_type):
     """Build a filter for an MLflow view type.
 
     Parameters
@@ -134,7 +134,7 @@ def filter_by_mlflow_view_type(view_type):
         raise ValueError("Invalid ViewType: {}".format(view_type))
 
 
-def parse_filter_string(mlflow_filter_string):
+def _parse_filter_string(mlflow_filter_string):
     """Parse an MLflow filter string into a Faculty filter object."""
     try:
         parsed = sqlparse.parse(mlflow_filter_string)

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -14,6 +14,7 @@ from sqlparse.tokens import Token as SqlTokenType
 from faculty.clients.experiment import (
     ComparisonOperator,
     CompoundFilter,
+    ExperimentIdFilter,
     ExperimentRunStatus,
     LogicalOperator,
     MetricFilter,
@@ -60,6 +61,22 @@ DISCRETE_OPERATORS = {
     ComparisonOperator.EQUAL_TO,
     ComparisonOperator.NOT_EQUAL_TO,
 }
+
+
+def filter_by_experiment_id(experiment_ids):
+    """Build a filter that a run is in one of a sequence of experiment IDs."""
+    if len(experiment_ids) == 0:
+        raise ValueError("Must pass at least one experiment ID")
+
+    parts = [
+        ExperimentIdFilter(ComparisonOperator.EQUAL_TO, int(experiment_id))
+        for experiment_id in experiment_ids
+    ]
+
+    if len(parts) == 1:
+        return parts[0]
+    else:
+        return CompoundFilter(LogicalOperator.OR, parts)
 
 
 def parse_filter_string(mlflow_filter_string):

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -227,35 +227,7 @@ def _split_list(source_list, condition):
 def _single_filter_from_tokens(identifier_token, operator_token, value_token):
     key_type, key = _parse_identifier(identifier_token)
     operator = _parse_operator(operator_token)
-
-    if operator == ComparisonOperator.DEFINED:
-        value = _extract_defined(value_token)
-    elif key_type == _KeyType.RUN_ID:
-        value_string = _extract_string(value_token)
-        try:
-            value = UUID(value_string)
-        except ValueError:
-            raise ValueError(INVALID_VALUE_TPL.format("a UUID", value_string))
-    elif key_type == _KeyType.STATUS:
-        value_string = _extract_string(value_token)
-        try:
-            value = ExperimentRunStatus(value_string.lower())
-        except ValueError:
-            valid_statuses = {
-                status.value.upper() for status in ExperimentRunStatus
-            }
-            raise ValueError(
-                INVALID_VALUE_TPL.format(
-                    "a run status (one of {})".format(valid_statuses),
-                    value_string,
-                )
-            )
-    elif key_type == _KeyType.PARAM:
-        value = _extract_number_or_string(value_token)
-    elif key_type == _KeyType.METRIC:
-        value = _extract_number(value_token)
-    elif key_type == _KeyType.TAG:
-        value = _extract_string(value_token)
+    value = _parse_value(key_type, operator, value_token)
 
     _validate_operator(key_type, operator, value)
 
@@ -311,6 +283,39 @@ def _parse_operator(token):
             raise ValueError(INVALID_OPERATOR_TPL.format(token.value))
     else:
         raise ValueError(INVALID_OPERATOR_TPL.format(token.value))
+
+
+def _parse_value(key_type, operator, value_token):
+    if operator == ComparisonOperator.DEFINED:
+        return _extract_defined(value_token)
+    elif key_type == _KeyType.RUN_ID:
+        value_string = _extract_string(value_token)
+        try:
+            return UUID(value_string)
+        except ValueError:
+            raise ValueError(INVALID_VALUE_TPL.format("a UUID", value_string))
+    elif key_type == _KeyType.STATUS:
+        value_string = _extract_string(value_token)
+        try:
+            return ExperimentRunStatus(value_string.lower())
+        except ValueError:
+            valid_statuses = {
+                status.value.upper() for status in ExperimentRunStatus
+            }
+            raise ValueError(
+                INVALID_VALUE_TPL.format(
+                    "a run status (one of {})".format(valid_statuses),
+                    value_string,
+                )
+            )
+    elif key_type == _KeyType.PARAM:
+        return _extract_number_or_string(value_token)
+    elif key_type == _KeyType.METRIC:
+        return _extract_number(value_token)
+    elif key_type == _KeyType.TAG:
+        return _extract_string(value_token)
+    else:
+        raise Exception("Unexpected key_type")
 
 
 def _validate_operator(key_type, operator, value):

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -23,18 +23,12 @@ from faculty.clients.experiment import (
     TagFilter,
 )
 
-STRING_VALUE_SQL_TYPES = {SqlTokenType.Literal.String.Single}
-NUMERIC_VALUE_SQL_TYPES = {
-    SqlTokenType.Literal.Number.Integer,
-    SqlTokenType.Literal.Number.Float,
-}
-
 INVALID_IDENTIFIER_TPL = (
-    "Expected param, metric or tag identifier of format "
-    "'metric.<key> <comparator> <value>', 'tag.<key> <comparator> <value>', "
-    "or 'params.<key> <comparator> <value>' but found '{token}'."
+    "Invalid identifier {!r}. Expected identifier of format "
+    "'attribute.run_id', 'attribute.status', 'metric.<key>', 'tag.<key>', "
+    "or 'params.<key>'."
 )
-INVALID_OPERATOR_TPL = "'{token}' is not a valid operator."
+INVALID_OPERATOR_TPL = "{!r} is not a valid operator."
 INVALID_VALUE_TPL = "Expected {} but found {!r}"
 
 
@@ -208,12 +202,12 @@ def _single_filter_from_tokens(identifier_token, operator_token, value_token):
 
 def _parse_identifier(token):
     if not isinstance(token, SqlIdentifier):
-        raise ValueError(INVALID_IDENTIFIER_TPL.format(token=token.value))
+        raise ValueError(INVALID_IDENTIFIER_TPL.format(token.value))
 
     try:
         key_type_string, key = token.value.split(".", 1)
     except ValueError:
-        raise ValueError(INVALID_IDENTIFIER_TPL.format(token=token.value))
+        raise ValueError(INVALID_IDENTIFIER_TPL.format(token.value))
 
     key = _strip_quotes(key, ['"', "`"])
 
@@ -223,7 +217,7 @@ def _parse_identifier(token):
         elif key == "status":
             return _KeyType.STATUS, None
         else:
-            raise ValueError("Unsupported filter attribute '{}'".format(key))
+            raise ValueError(INVALID_IDENTIFIER_TPL.format(token.value))
     elif key_type_string in PARAM_IDENTIFIERS:
         return _KeyType.PARAM, key
     elif key_type_string in METRIC_IDENTIFIERS:
@@ -231,7 +225,7 @@ def _parse_identifier(token):
     elif key_type_string in TAG_IDENTIFIERS:
         return _KeyType.TAG, key
     else:
-        raise ValueError("Unsupported filter '{}'.".format(token.value))
+        raise ValueError(INVALID_IDENTIFIER_TPL.format(token.value))
 
 
 def _parse_operator(token):
@@ -241,9 +235,9 @@ def _parse_operator(token):
         try:
             return COMPARISON_OPERATOR_MAPPING[token.value]
         except KeyError:
-            raise ValueError(INVALID_OPERATOR_TPL.format(token=token.value))
+            raise ValueError(INVALID_OPERATOR_TPL.format(token.value))
     else:
-        raise ValueError(INVALID_OPERATOR_TPL.format(token=token.value))
+        raise ValueError(INVALID_OPERATOR_TPL.format(token.value))
 
 
 def _validate_operator(key_type, operator, value):

--- a/mlflow_faculty/filter.py
+++ b/mlflow_faculty/filter.py
@@ -46,7 +46,7 @@ class _KeyType(Enum):
 
 
 ATTRIBUTE_IDENTIFIERS = {"attribute", "attributes", "attr", "run"}
-RUN_ID_IDENTIFIERS = {"id", "run_id", "runId"}
+RUN_ID_IDENTIFIERS = {"id", "run_id"}
 PARAM_IDENTIFIERS = {"param", "params", "parameter", "parameters"}
 METRIC_IDENTIFIERS = {"metric", "metrics"}
 TAG_IDENTIFIERS = {"tag", "tags"}

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=[
         "mlflow==1.2.0",
-        "faculty>=0.24.5",
+        "faculty>=0.25.1",
         "enum34; python_version<'3.4'",
         "six",
         "pytz",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,14 @@ setup(
     packages=find_packages(),
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
-    install_requires=["mlflow==1.2.0", "faculty>=0.24.5", "six", "pytz"],
+    install_requires=[
+        "mlflow==1.2.0",
+        "faculty>=0.24.5",
+        "enum34; python_version<'3.4'",
+        "six",
+        "pytz",
+        "sqlparse",
+    ],
     entry_points={
         "mlflow.tracking_store": TRACKING_STORE_ENTRYPOINT,
         "mlflow.artifact_repository": ARTIFACT_REPOSITORY_ENTRYPOINT,

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -5,6 +5,7 @@ import pytest
 from faculty.clients.experiment import (
     ComparisonOperator,
     CompoundFilter,
+    DeletedAtFilter,
     ExperimentIdFilter,
     ExperimentRunStatus,
     LogicalOperator,
@@ -14,8 +15,13 @@ from faculty.clients.experiment import (
     RunStatusFilter,
     TagFilter,
 )
+from mlflow.entities import ViewType
 
-from mlflow_faculty.filter import filter_by_experiment_id, parse_filter_string
+from mlflow_faculty.filter import (
+    filter_by_experiment_id,
+    filter_by_mlflow_view_type,
+    parse_filter_string,
+)
 
 
 @pytest.mark.parametrize(
@@ -51,6 +57,24 @@ def test_filter_by_experiment_id(experiment_ids, expected_filter):
 def test_filter_by_experiment_id_empty_list():
     with pytest.raises(ValueError):
         filter_by_experiment_id([])
+
+
+@pytest.mark.parametrize(
+    "view_type, expected_filter",
+    [
+        (
+            ViewType.DELETED_ONLY,
+            DeletedAtFilter(ComparisonOperator.DEFINED, True),
+        ),
+        (
+            ViewType.ACTIVE_ONLY,
+            DeletedAtFilter(ComparisonOperator.DEFINED, False),
+        ),
+        (ViewType.ALL, None),
+    ],
+)
+def test_filter_by_mlflow_view_type(view_type, expected_filter):
+    assert filter_by_mlflow_view_type(view_type) == expected_filter
 
 
 ATTRIBUTE_IDENTIFIERS = ["attribute", "attributes", "attr", "run"]

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -277,3 +277,22 @@ def test_parse_filter_string_parentheses(filter_string, expected_filter):
     filter = parse_filter_string(filter_string)
     assert filter == expected_filter
     assert isinstance(filter, type(expected_filter))
+
+
+@pytest.mark.parametrize(
+    "filter_string",
+    [
+        "param.alpha IS 'a string'",
+        "param.alpha = string",
+        "metric.accuracy = 'a string'",
+        "tag.`class.name` = 34",
+        "run.id = NULL",
+        "attr.status = NOT NULL",
+        "run.id = 'not-a-uuid'",
+        "attr.status = 'not-a-valid-status'",
+        "param.alpha = `a string`",
+    ],
+)
+def test_parse_filter_string_invalid_value(filter_string):
+    with pytest.raises(ValueError, match="Expected .* but found .*"):
+        parse_filter_string(filter_string)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -21,9 +21,9 @@ import mlflow_faculty.filter
 from mlflow_faculty.filter import (
     MatchesNothing,
     build_search_runs_filter,
-    filter_by_experiment_id,
-    filter_by_mlflow_view_type,
-    parse_filter_string,
+    _filter_by_experiment_id,
+    _filter_by_mlflow_view_type,
+    _parse_filter_string,
 )
 
 
@@ -32,29 +32,29 @@ def test_build_search_runs_filter(mocker):
     view_type = mocker.Mock()
     filter_string = "param.alpha > 0.2"
 
-    mocker.patch("mlflow_faculty.filter.filter_by_experiment_id")
-    mocker.patch("mlflow_faculty.filter.filter_by_mlflow_view_type")
-    mocker.patch("mlflow_faculty.filter.parse_filter_string")
+    mocker.patch("mlflow_faculty.filter._filter_by_experiment_id")
+    mocker.patch("mlflow_faculty.filter._filter_by_mlflow_view_type")
+    mocker.patch("mlflow_faculty.filter._parse_filter_string")
 
     expected_filter = CompoundFilter(
         LogicalOperator.AND,
         [
-            mlflow_faculty.filter.filter_by_experiment_id.return_value,
-            mlflow_faculty.filter.filter_by_mlflow_view_type.return_value,
-            mlflow_faculty.filter.parse_filter_string.return_value,
+            mlflow_faculty.filter._filter_by_experiment_id.return_value,
+            mlflow_faculty.filter._filter_by_mlflow_view_type.return_value,
+            mlflow_faculty.filter._parse_filter_string.return_value,
         ],
     )
 
     filter = build_search_runs_filter(experiment_ids, filter_string, view_type)
     assert filter == expected_filter
 
-    mlflow_faculty.filter.filter_by_experiment_id.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_experiment_id.assert_called_once_with(
         experiment_ids
     )
-    mlflow_faculty.filter.filter_by_mlflow_view_type.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_mlflow_view_type.assert_called_once_with(
         view_type
     )
-    mlflow_faculty.filter.parse_filter_string.assert_called_once_with(
+    mlflow_faculty.filter._parse_filter_string.assert_called_once_with(
         filter_string
     )
 
@@ -64,26 +64,26 @@ def test_build_search_runs_filter_no_experiment_ids(mocker):
     view_type = mocker.Mock()
     filter_string = "param.alpha > 0.2"
 
-    mocker.patch("mlflow_faculty.filter.filter_by_experiment_id")
-    mocker.patch("mlflow_faculty.filter.filter_by_mlflow_view_type")
-    mocker.patch("mlflow_faculty.filter.parse_filter_string")
+    mocker.patch("mlflow_faculty.filter._filter_by_experiment_id")
+    mocker.patch("mlflow_faculty.filter._filter_by_mlflow_view_type")
+    mocker.patch("mlflow_faculty.filter._parse_filter_string")
 
     expected_filter = CompoundFilter(
         LogicalOperator.AND,
         [
-            mlflow_faculty.filter.filter_by_mlflow_view_type.return_value,
-            mlflow_faculty.filter.parse_filter_string.return_value,
+            mlflow_faculty.filter._filter_by_mlflow_view_type.return_value,
+            mlflow_faculty.filter._parse_filter_string.return_value,
         ],
     )
 
     filter = build_search_runs_filter(experiment_ids, filter_string, view_type)
     assert filter == expected_filter
 
-    mlflow_faculty.filter.filter_by_experiment_id.assert_not_called()
-    mlflow_faculty.filter.filter_by_mlflow_view_type.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_experiment_id.assert_not_called()
+    mlflow_faculty.filter._filter_by_mlflow_view_type.assert_called_once_with(
         view_type
     )
-    mlflow_faculty.filter.parse_filter_string.assert_called_once_with(
+    mlflow_faculty.filter._parse_filter_string.assert_called_once_with(
         filter_string
     )
 
@@ -93,30 +93,30 @@ def test_build_search_runs_filter_no_view_type_filer(mocker):
     view_type = mocker.Mock()
     filter_string = "param.alpha > 0.2"
 
-    mocker.patch("mlflow_faculty.filter.filter_by_experiment_id")
+    mocker.patch("mlflow_faculty.filter._filter_by_experiment_id")
     mocker.patch(
-        "mlflow_faculty.filter.filter_by_mlflow_view_type", return_value=None
+        "mlflow_faculty.filter._filter_by_mlflow_view_type", return_value=None
     )
-    mocker.patch("mlflow_faculty.filter.parse_filter_string")
+    mocker.patch("mlflow_faculty.filter._parse_filter_string")
 
     expected_filter = CompoundFilter(
         LogicalOperator.AND,
         [
-            mlflow_faculty.filter.filter_by_experiment_id.return_value,
-            mlflow_faculty.filter.parse_filter_string.return_value,
+            mlflow_faculty.filter._filter_by_experiment_id.return_value,
+            mlflow_faculty.filter._parse_filter_string.return_value,
         ],
     )
 
     filter = build_search_runs_filter(experiment_ids, filter_string, view_type)
     assert filter == expected_filter
 
-    mlflow_faculty.filter.filter_by_experiment_id.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_experiment_id.assert_called_once_with(
         experiment_ids
     )
-    mlflow_faculty.filter.filter_by_mlflow_view_type.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_mlflow_view_type.assert_called_once_with(
         view_type
     )
-    mlflow_faculty.filter.parse_filter_string.assert_called_once_with(
+    mlflow_faculty.filter._parse_filter_string.assert_called_once_with(
         filter_string
     )
 
@@ -126,28 +126,28 @@ def test_build_search_runs_filter_no_filter_string(mocker, filter_string):
     experiment_ids = [1, 2, 3]
     view_type = mocker.Mock()
 
-    mocker.patch("mlflow_faculty.filter.filter_by_experiment_id")
-    mocker.patch("mlflow_faculty.filter.filter_by_mlflow_view_type")
-    mocker.patch("mlflow_faculty.filter.parse_filter_string")
+    mocker.patch("mlflow_faculty.filter._filter_by_experiment_id")
+    mocker.patch("mlflow_faculty.filter._filter_by_mlflow_view_type")
+    mocker.patch("mlflow_faculty.filter._parse_filter_string")
 
     expected_filter = CompoundFilter(
         LogicalOperator.AND,
         [
-            mlflow_faculty.filter.filter_by_experiment_id.return_value,
-            mlflow_faculty.filter.filter_by_mlflow_view_type.return_value,
+            mlflow_faculty.filter._filter_by_experiment_id.return_value,
+            mlflow_faculty.filter._filter_by_mlflow_view_type.return_value,
         ],
     )
 
     filter = build_search_runs_filter(experiment_ids, filter_string, view_type)
     assert filter == expected_filter
 
-    mlflow_faculty.filter.filter_by_experiment_id.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_experiment_id.assert_called_once_with(
         experiment_ids
     )
-    mlflow_faculty.filter.filter_by_mlflow_view_type.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_mlflow_view_type.assert_called_once_with(
         view_type
     )
-    mlflow_faculty.filter.parse_filter_string.assert_not_called()
+    mlflow_faculty.filter._parse_filter_string.assert_not_called()
 
 
 def test_build_search_runs_filter_only_experiment_ids(mocker):
@@ -155,26 +155,26 @@ def test_build_search_runs_filter_only_experiment_ids(mocker):
     view_type = mocker.Mock()
     filter_string = ""
 
-    mocker.patch("mlflow_faculty.filter.filter_by_experiment_id")
+    mocker.patch("mlflow_faculty.filter._filter_by_experiment_id")
     mocker.patch(
-        "mlflow_faculty.filter.filter_by_mlflow_view_type", return_value=None
+        "mlflow_faculty.filter._filter_by_mlflow_view_type", return_value=None
     )
-    mocker.patch("mlflow_faculty.filter.parse_filter_string")
+    mocker.patch("mlflow_faculty.filter._parse_filter_string")
 
     expected_filter = (
-        mlflow_faculty.filter.filter_by_experiment_id.return_value
+        mlflow_faculty.filter._filter_by_experiment_id.return_value
     )
 
     filter = build_search_runs_filter(experiment_ids, filter_string, view_type)
     assert filter == expected_filter
 
-    mlflow_faculty.filter.filter_by_experiment_id.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_experiment_id.assert_called_once_with(
         experiment_ids
     )
-    mlflow_faculty.filter.filter_by_mlflow_view_type.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_mlflow_view_type.assert_called_once_with(
         view_type
     )
-    mlflow_faculty.filter.parse_filter_string.assert_not_called()
+    mlflow_faculty.filter._parse_filter_string.assert_not_called()
 
 
 def test_build_search_runs_filter_only_view_type(mocker):
@@ -182,22 +182,22 @@ def test_build_search_runs_filter_only_view_type(mocker):
     view_type = mocker.Mock()
     filter_string = ""
 
-    mocker.patch("mlflow_faculty.filter.filter_by_experiment_id")
-    mocker.patch("mlflow_faculty.filter.filter_by_mlflow_view_type")
-    mocker.patch("mlflow_faculty.filter.parse_filter_string")
+    mocker.patch("mlflow_faculty.filter._filter_by_experiment_id")
+    mocker.patch("mlflow_faculty.filter._filter_by_mlflow_view_type")
+    mocker.patch("mlflow_faculty.filter._parse_filter_string")
 
     expected_filter = (
-        mlflow_faculty.filter.filter_by_mlflow_view_type.return_value
+        mlflow_faculty.filter._filter_by_mlflow_view_type.return_value
     )
 
     filter = build_search_runs_filter(experiment_ids, filter_string, view_type)
     assert filter == expected_filter
 
-    mlflow_faculty.filter.filter_by_experiment_id.assert_not_called()
-    mlflow_faculty.filter.filter_by_mlflow_view_type.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_experiment_id.assert_not_called()
+    mlflow_faculty.filter._filter_by_mlflow_view_type.assert_called_once_with(
         view_type
     )
-    mlflow_faculty.filter.parse_filter_string.assert_not_called()
+    mlflow_faculty.filter._parse_filter_string.assert_not_called()
 
 
 def test_build_search_runs_filter_only_filter_string(mocker):
@@ -205,22 +205,22 @@ def test_build_search_runs_filter_only_filter_string(mocker):
     view_type = mocker.Mock()
     filter_string = "param.alpha > 0.2"
 
-    mocker.patch("mlflow_faculty.filter.filter_by_experiment_id")
+    mocker.patch("mlflow_faculty.filter._filter_by_experiment_id")
     mocker.patch(
-        "mlflow_faculty.filter.filter_by_mlflow_view_type", return_value=None
+        "mlflow_faculty.filter._filter_by_mlflow_view_type", return_value=None
     )
-    mocker.patch("mlflow_faculty.filter.parse_filter_string")
+    mocker.patch("mlflow_faculty.filter._parse_filter_string")
 
-    expected_filter = mlflow_faculty.filter.parse_filter_string.return_value
+    expected_filter = mlflow_faculty.filter._parse_filter_string.return_value
 
     filter = build_search_runs_filter(experiment_ids, filter_string, view_type)
     assert filter == expected_filter
 
-    mlflow_faculty.filter.filter_by_experiment_id.assert_not_called()
-    mlflow_faculty.filter.filter_by_mlflow_view_type.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_experiment_id.assert_not_called()
+    mlflow_faculty.filter._filter_by_mlflow_view_type.assert_called_once_with(
         view_type
     )
-    mlflow_faculty.filter.parse_filter_string.assert_called_once_with(
+    mlflow_faculty.filter._parse_filter_string.assert_called_once_with(
         filter_string
     )
 
@@ -230,20 +230,20 @@ def test_build_search_runs_filter_no_filters(mocker):
     view_type = mocker.Mock()
     filter_string = ""
 
-    mocker.patch("mlflow_faculty.filter.filter_by_experiment_id")
+    mocker.patch("mlflow_faculty.filter._filter_by_experiment_id")
     mocker.patch(
-        "mlflow_faculty.filter.filter_by_mlflow_view_type", return_value=None
+        "mlflow_faculty.filter._filter_by_mlflow_view_type", return_value=None
     )
-    mocker.patch("mlflow_faculty.filter.parse_filter_string")
+    mocker.patch("mlflow_faculty.filter._parse_filter_string")
 
     filter = build_search_runs_filter(experiment_ids, filter_string, view_type)
     assert filter is None
 
-    mlflow_faculty.filter.filter_by_experiment_id.assert_not_called()
-    mlflow_faculty.filter.filter_by_mlflow_view_type.assert_called_once_with(
+    mlflow_faculty.filter._filter_by_experiment_id.assert_not_called()
+    mlflow_faculty.filter._filter_by_mlflow_view_type.assert_called_once_with(
         view_type
     )
-    mlflow_faculty.filter.parse_filter_string.assert_not_called()
+    mlflow_faculty.filter._parse_filter_string.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -273,17 +273,17 @@ def test_build_search_runs_filter_no_filters(mocker):
     ],
 )
 def test_filter_by_experiment_id(experiment_ids, expected_filter):
-    assert filter_by_experiment_id(experiment_ids) == expected_filter
+    assert _filter_by_experiment_id(experiment_ids) == expected_filter
 
 
 def test_filter_by_experiment_id_invalid_id():
     with pytest.raises(ValueError):
-        filter_by_experiment_id("not a valid integer")
+        _filter_by_experiment_id("not a valid integer")
 
 
 def test_filter_by_experiment_id_empty_list():
     with pytest.raises(MatchesNothing):
-        filter_by_experiment_id([])
+        _filter_by_experiment_id([])
 
 
 @pytest.mark.parametrize(
@@ -301,7 +301,7 @@ def test_filter_by_experiment_id_empty_list():
     ],
 )
 def test_filter_by_mlflow_view_type(view_type, expected_filter):
-    assert filter_by_mlflow_view_type(view_type) == expected_filter
+    assert _filter_by_mlflow_view_type(view_type) == expected_filter
 
 
 ATTRIBUTE_IDENTIFIERS = ["attribute", "attributes", "attr", "run"]
@@ -452,7 +452,7 @@ def _single_test_cases():
     "filter_string, expected_filter", _single_test_cases()
 )
 def test_parse_filter_string_single(filter_string, expected_filter):
-    filter = parse_filter_string(filter_string)
+    filter = _parse_filter_string(filter_string)
     assert filter == expected_filter
     assert isinstance(filter, type(expected_filter))
 
@@ -508,7 +508,7 @@ def test_parse_filter_string_logical_operator(
     expected_filter = CompoundFilter(
         expected_operator, [left_filter, right_filter]
     )
-    filter = parse_filter_string(filter_string)
+    filter = _parse_filter_string(filter_string)
     assert filter == expected_filter
     assert isinstance(filter, type(expected_filter))
 
@@ -526,7 +526,7 @@ OPERATOR_PRECEDENCE_FILTER = CompoundFilter(
 
 
 def test_parse_filter_string_operator_precedence():
-    filter = parse_filter_string(OPERATOR_PRECEDENCE_FILTER_STRING)
+    filter = _parse_filter_string(OPERATOR_PRECEDENCE_FILTER_STRING)
     assert filter == OPERATOR_PRECEDENCE_FILTER
     assert isinstance(filter, type(OPERATOR_PRECEDENCE_FILTER))
 
@@ -577,7 +577,7 @@ NESTED_PAREN_FILTER = CompoundFilter(
     ],
 )
 def test_parse_filter_string_parentheses(filter_string, expected_filter):
-    filter = parse_filter_string(filter_string)
+    filter = _parse_filter_string(filter_string)
     assert filter == expected_filter
     assert isinstance(filter, type(expected_filter))
 
@@ -593,12 +593,12 @@ def test_parse_filter_string_parentheses(filter_string, expected_filter):
 )
 def test_parse_filter_string_invalid_identifier(filter_string):
     with pytest.raises(ValueError, match="Invalid identifier"):
-        parse_filter_string(filter_string)
+        _parse_filter_string(filter_string)
 
 
 def test_parse_filter_string_unrecognised_operator():
     with pytest.raises(ValueError, match="is not a valid operator"):
-        parse_filter_string("param.alpha IN 'a string'")
+        _parse_filter_string("param.alpha IN 'a string'")
 
 
 @pytest.mark.parametrize(
@@ -617,7 +617,7 @@ def test_parse_filter_string_unrecognised_operator():
 )
 def test_parse_filter_string_invalid_value(filter_string):
     with pytest.raises(ValueError, match="Expected .* but found .*"):
-        parse_filter_string(filter_string)
+        _parse_filter_string(filter_string)
 
 
 @pytest.mark.parametrize(
@@ -631,4 +631,4 @@ def test_parse_filter_string_invalid_value(filter_string):
 )
 def test_parse_filter_string_invalid_operator(filter_string):
     with pytest.raises(ValueError, match="can only be used with operators"):
-        parse_filter_string(filter_string)
+        _parse_filter_string(filter_string)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -82,7 +82,7 @@ def _build_test_cases(builder, identifier, operator_cases, value_cases):
 
 def _run_id_test_cases():
     for type_identifier in ATTRIBUTE_IDENTIFIERS:
-        for sql_key in ["id", "run_id", "runId", '"id"', "`run_id`"]:
+        for sql_key in ["id", "run_id", '"id"', "`run_id`"]:
             identifier = "{}.{}".format(type_identifier, sql_key)
             yield from _build_defined_test_cases(RunIdFilter, identifier)
             yield from _build_test_cases(
@@ -147,7 +147,132 @@ def _single_test_cases():
 @pytest.mark.parametrize(
     "filter_string, expected_filter", _single_test_cases()
 )
-def test_single(filter_string, expected_filter):
+def test_parse_filter_string_single(filter_string, expected_filter):
+    filter = parse_filter_string(filter_string)
+    assert filter == expected_filter
+    assert isinstance(filter, type(expected_filter))
+
+
+RUN_ID_FILTER_STRING = 'attribute.run_id = "{}"'.format(RUN_ID)
+RUN_ID_FILTER = RunIdFilter(ComparisonOperator.EQUAL_TO, RUN_ID)
+
+STATUS_FILTER_STRING = 'run.status != "FINISHED"'
+STATUS_FILTER = RunStatusFilter(
+    ComparisonOperator.NOT_EQUAL_TO, ExperimentRunStatus.FINISHED
+)
+
+PARAM_FILTER_STRING = "param.alpha > 20"
+PARAM_FILTER = ParamFilter("alpha", ComparisonOperator.GREATER_THAN, 20)
+
+METRIC_FILTER_STRING = "metric.accuracy IS NOT NULL"
+METRIC_FILTER = MetricFilter("accuracy", ComparisonOperator.DEFINED, True)
+
+TAG_FILTER_STRING = "tag.`class.name` IS NULL"
+TAG_FILTER = TagFilter("class.name", ComparisonOperator.DEFINED, False)
+
+REDUCED_SINGLE_TEST_CASES = [
+    (RUN_ID_FILTER_STRING, RUN_ID_FILTER),
+    (STATUS_FILTER_STRING, STATUS_FILTER),
+    (PARAM_FILTER_STRING, PARAM_FILTER),
+    (METRIC_FILTER_STRING, METRIC_FILTER),
+    (TAG_FILTER_STRING, TAG_FILTER),
+]
+
+
+@pytest.mark.parametrize(
+    "sql_operator, expected_operator",
+    [
+        ("AND", LogicalOperator.AND),
+        ("and", LogicalOperator.AND),
+        ("OR", LogicalOperator.OR),
+        ("or", LogicalOperator.OR),
+    ],
+)
+@pytest.mark.parametrize("left_string, left_filter", REDUCED_SINGLE_TEST_CASES)
+@pytest.mark.parametrize(
+    "right_string, right_filter", REDUCED_SINGLE_TEST_CASES
+)
+def test_parse_filter_string_logical_operator(
+    sql_operator,
+    expected_operator,
+    left_string,
+    left_filter,
+    right_string,
+    right_filter,
+):
+    filter_string = "{} {} {}".format(left_string, sql_operator, right_string)
+    expected_filter = CompoundFilter(
+        expected_operator, [left_filter, right_filter]
+    )
+    filter = parse_filter_string(filter_string)
+    assert filter == expected_filter
+    assert isinstance(filter, type(expected_filter))
+
+
+OPERATOR_PRECEDENCE_FILTER_STRING = "{} AND {} OR {}".format(
+    RUN_ID_FILTER_STRING, STATUS_FILTER_STRING, METRIC_FILTER_STRING
+)
+OPERATOR_PRECEDENCE_FILTER = CompoundFilter(
+    LogicalOperator.OR,
+    [
+        CompoundFilter(LogicalOperator.AND, [RUN_ID_FILTER, STATUS_FILTER]),
+        METRIC_FILTER,
+    ],
+)
+
+
+def test_parse_filter_string_operator_precedence():
+    filter = parse_filter_string(OPERATOR_PRECEDENCE_FILTER_STRING)
+    assert filter == OPERATOR_PRECEDENCE_FILTER
+    assert isinstance(filter, type(OPERATOR_PRECEDENCE_FILTER))
+
+
+PAREN_FILTER_STRING = "{} AND ({} OR {}) ".format(
+    RUN_ID_FILTER_STRING, STATUS_FILTER_STRING, METRIC_FILTER_STRING
+)
+PAREN_FILTER = CompoundFilter(
+    LogicalOperator.AND,
+    [
+        RUN_ID_FILTER,
+        CompoundFilter(LogicalOperator.OR, [STATUS_FILTER, METRIC_FILTER]),
+    ],
+)
+
+NESTED_PAREN_FILTER_STRING = "({} OR {} OR ({} AND {})) AND {}".format(
+    RUN_ID_FILTER_STRING,
+    STATUS_FILTER_STRING,
+    PARAM_FILTER_STRING,
+    METRIC_FILTER_STRING,
+    TAG_FILTER_STRING,
+)
+NESTED_PAREN_FILTER = CompoundFilter(
+    LogicalOperator.AND,
+    [
+        CompoundFilter(
+            LogicalOperator.OR,
+            [
+                RUN_ID_FILTER,
+                STATUS_FILTER,
+                CompoundFilter(
+                    LogicalOperator.AND, [PARAM_FILTER, METRIC_FILTER]
+                ),
+            ],
+        ),
+        TAG_FILTER,
+    ],
+)
+
+
+@pytest.mark.parametrize(
+    "filter_string, expected_filter",
+    [
+        ("({})".format(RUN_ID_FILTER_STRING), RUN_ID_FILTER),
+        (" ( {} ) ".format(STATUS_FILTER_STRING), STATUS_FILTER),
+        (PAREN_FILTER_STRING, PAREN_FILTER),
+        (NESTED_PAREN_FILTER_STRING, NESTED_PAREN_FILTER),
+    ],
+)
+def test_parse_filter_string_parentheses(filter_string, expected_filter):
     filter = parse_filter_string(filter_string)
     assert filter == expected_filter
     assert isinstance(filter, type(expected_filter))

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -352,84 +352,100 @@ NUMBER_CASES = [("2", 2), ("2.1", 2.1)]
 
 
 def _build_defined_test_cases(builder, identifier):
+    cases = []
     for sql_condition, defined in DEFINED_CASES:
         filter_string = "{} {}".format(identifier, sql_condition)
         expected_filter = builder(ComparisonOperator.DEFINED, defined)
-        yield filter_string, expected_filter
+        cases.append((filter_string, expected_filter))
+    return cases
 
 
 def _build_test_cases(builder, identifier, operator_cases, value_cases):
+    cases = []
     for sql_operator, expected_operator in operator_cases:
         for sql_value, expected_value in value_cases:
             filter_string = "{} {} {}".format(
                 identifier, sql_operator, sql_value
             )
             expected_filter = builder(expected_operator, expected_value)
-            yield filter_string, expected_filter
+            cases.append((filter_string, expected_filter))
+    return cases
 
 
 def _run_id_test_cases():
+    cases = []
     for type_identifier in ATTRIBUTE_IDENTIFIERS:
         for sql_key in ["id", "run_id", '"id"', "`run_id`"]:
             identifier = "{}.{}".format(type_identifier, sql_key)
-            yield from _build_defined_test_cases(RunIdFilter, identifier)
-            yield from _build_test_cases(
+            cases += _build_defined_test_cases(RunIdFilter, identifier)
+            cases += _build_test_cases(
                 RunIdFilter, identifier, DISCRETE_OP_CASES, RUN_ID_CASES
             )
+    return cases
 
 
 def _status_test_cases():
+    cases = []
     for type_identifier in ATTRIBUTE_IDENTIFIERS:
         for sql_key in ["status", '"status"', "`status`"]:
             identifier = "{}.{}".format(type_identifier, sql_key)
-            yield from _build_defined_test_cases(RunStatusFilter, identifier)
-            yield from _build_test_cases(
+            cases += _build_defined_test_cases(RunStatusFilter, identifier)
+            cases += _build_test_cases(
                 RunStatusFilter, identifier, DISCRETE_OP_CASES, STATUS_CASES
             )
+    return cases
 
 
 def _param_test_cases():
+    cases = []
     for type_identifier in ["param", "params", "parameter", "parameters"]:
         for sql_key, expected_key in KEY_CASES:
             identifier = "{}.{}".format(type_identifier, sql_key)
             filter_builder = partial(ParamFilter, expected_key)
-            yield from _build_defined_test_cases(filter_builder, identifier)
-            yield from _build_test_cases(
+            cases += _build_defined_test_cases(filter_builder, identifier)
+            cases += _build_test_cases(
                 filter_builder, identifier, DISCRETE_OP_CASES, STRING_CASES
             )
-            yield from _build_test_cases(
+            cases += _build_test_cases(
                 filter_builder, identifier, CONTINUOUS_OP_CASES, NUMBER_CASES
             )
+    return cases
 
 
 def _metric_test_cases():
+    cases = []
     for type_identifier in ["metric", "metrics"]:
         for sql_key, expected_key in KEY_CASES:
             identifier = "{}.{}".format(type_identifier, sql_key)
             filter_builder = partial(MetricFilter, expected_key)
-            yield from _build_defined_test_cases(filter_builder, identifier)
-            yield from _build_test_cases(
+            cases += _build_defined_test_cases(filter_builder, identifier)
+            cases += _build_test_cases(
                 filter_builder, identifier, CONTINUOUS_OP_CASES, NUMBER_CASES
             )
+    return cases
 
 
 def _tag_test_cases():
+    cases = []
     for type_identifier in ["tag", "tags"]:
         for sql_key, expected_key in KEY_CASES:
             identifier = "{}.{}".format(type_identifier, sql_key)
             filter_builder = partial(TagFilter, expected_key)
-            yield from _build_defined_test_cases(filter_builder, identifier)
-            yield from _build_test_cases(
+            cases += _build_defined_test_cases(filter_builder, identifier)
+            cases += _build_test_cases(
                 filter_builder, identifier, DISCRETE_OP_CASES, STRING_CASES
             )
+    return cases
 
 
 def _single_test_cases():
-    yield from _run_id_test_cases()
-    yield from _status_test_cases()
-    yield from _param_test_cases()
-    yield from _metric_test_cases()
-    yield from _tag_test_cases()
+    cases = []
+    cases += _run_id_test_cases()
+    cases += _status_test_cases()
+    cases += _param_test_cases()
+    cases += _metric_test_cases()
+    cases += _tag_test_cases()
+    return cases
 
 
 @pytest.mark.parametrize(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,153 @@
+from functools import partial
+from uuid import uuid4
+
+import pytest
+from faculty.clients.experiment import (
+    ComparisonOperator,
+    CompoundFilter,
+    ExperimentRunStatus,
+    LogicalOperator,
+    MetricFilter,
+    ParamFilter,
+    RunIdFilter,
+    RunStatusFilter,
+    TagFilter,
+)
+
+from mlflow_faculty.filter import parse_filter_string
+
+ATTRIBUTE_IDENTIFIERS = ["attribute", "attributes", "attr", "run"]
+
+DEFINED_CASES = [
+    ("IS NULL", False),
+    ("IS NOT NULL", True),
+    ("is null", False),
+    ("is not null", True),
+    ("IS  Null", False),
+    ("IS   Not   Null", True),
+]
+
+DISCRETE_OP_CASES = [
+    ("=", ComparisonOperator.EQUAL_TO),
+    ("!=", ComparisonOperator.NOT_EQUAL_TO),
+]
+
+CONTINUOUS_OP_CASES = DISCRETE_OP_CASES + [
+    (">", ComparisonOperator.GREATER_THAN),
+    (">=", ComparisonOperator.GREATER_THAN_OR_EQUAL_TO),
+    ("<", ComparisonOperator.LESS_THAN),
+    ("<=", ComparisonOperator.LESS_THAN_OR_EQUAL_TO),
+]
+
+KEY_CASES = [
+    ("alpha", "alpha"),
+    ('"alpha-1"', "alpha-1"),
+    ("`alpha.1`", "alpha.1"),
+]
+
+RUN_ID = uuid4()
+RUN_ID_CASES = [
+    ("'{}'".format(RUN_ID), RUN_ID),
+    ('"{}"'.format(RUN_ID), RUN_ID),
+]
+STATUS_CASES = [
+    ("'running'", ExperimentRunStatus.RUNNING),
+    ('"finished"', ExperimentRunStatus.FINISHED),
+    ("'failed'", ExperimentRunStatus.FAILED),
+    ('"scheduled"', ExperimentRunStatus.SCHEDULED),
+    ("'killed'", ExperimentRunStatus.KILLED),
+    ('"Running"', ExperimentRunStatus.RUNNING),
+    ("'FINISHED'", ExperimentRunStatus.FINISHED),
+]
+STRING_CASES = [("'value'", "value"), ('"value"', "value")]
+NUMBER_CASES = [("2", 2), ("2.1", 2.1)]
+
+
+def _build_defined_test_cases(builder, identifier):
+    for sql_condition, defined in DEFINED_CASES:
+        filter_string = "{} {}".format(identifier, sql_condition)
+        expected_filter = builder(ComparisonOperator.DEFINED, defined)
+        yield filter_string, expected_filter
+
+
+def _build_test_cases(builder, identifier, operator_cases, value_cases):
+    for sql_operator, expected_operator in operator_cases:
+        for sql_value, expected_value in value_cases:
+            filter_string = "{} {} {}".format(
+                identifier, sql_operator, sql_value
+            )
+            expected_filter = builder(expected_operator, expected_value)
+            yield filter_string, expected_filter
+
+
+def _run_id_test_cases():
+    for type_identifier in ATTRIBUTE_IDENTIFIERS:
+        for sql_key in ["id", "run_id", "runId", '"id"', "`run_id`"]:
+            identifier = "{}.{}".format(type_identifier, sql_key)
+            yield from _build_defined_test_cases(RunIdFilter, identifier)
+            yield from _build_test_cases(
+                RunIdFilter, identifier, DISCRETE_OP_CASES, RUN_ID_CASES
+            )
+
+
+def _status_test_cases():
+    for type_identifier in ATTRIBUTE_IDENTIFIERS:
+        for sql_key in ["status", '"status"', "`status`"]:
+            identifier = "{}.{}".format(type_identifier, sql_key)
+            yield from _build_defined_test_cases(RunStatusFilter, identifier)
+            yield from _build_test_cases(
+                RunStatusFilter, identifier, DISCRETE_OP_CASES, STATUS_CASES
+            )
+
+
+def _param_test_cases():
+    for type_identifier in ["param", "params", "parameter", "parameters"]:
+        for sql_key, expected_key in KEY_CASES:
+            identifier = "{}.{}".format(type_identifier, sql_key)
+            filter_builder = partial(ParamFilter, expected_key)
+            yield from _build_defined_test_cases(filter_builder, identifier)
+            yield from _build_test_cases(
+                filter_builder, identifier, DISCRETE_OP_CASES, STRING_CASES
+            )
+            yield from _build_test_cases(
+                filter_builder, identifier, CONTINUOUS_OP_CASES, NUMBER_CASES
+            )
+
+
+def _metric_test_cases():
+    for type_identifier in ["metric", "metrics"]:
+        for sql_key, expected_key in KEY_CASES:
+            identifier = "{}.{}".format(type_identifier, sql_key)
+            filter_builder = partial(MetricFilter, expected_key)
+            yield from _build_defined_test_cases(filter_builder, identifier)
+            yield from _build_test_cases(
+                filter_builder, identifier, CONTINUOUS_OP_CASES, NUMBER_CASES
+            )
+
+
+def _tag_test_cases():
+    for type_identifier in ["tag", "tags"]:
+        for sql_key, expected_key in KEY_CASES:
+            identifier = "{}.{}".format(type_identifier, sql_key)
+            filter_builder = partial(TagFilter, expected_key)
+            yield from _build_defined_test_cases(filter_builder, identifier)
+            yield from _build_test_cases(
+                filter_builder, identifier, DISCRETE_OP_CASES, STRING_CASES
+            )
+
+
+def _single_test_cases():
+    yield from _run_id_test_cases()
+    yield from _status_test_cases()
+    yield from _param_test_cases()
+    yield from _metric_test_cases()
+    yield from _tag_test_cases()
+
+
+@pytest.mark.parametrize(
+    "filter_string, expected_filter", _single_test_cases()
+)
+def test_single(filter_string, expected_filter):
+    filter = parse_filter_string(filter_string)
+    assert filter == expected_filter
+    assert isinstance(filter, type(expected_filter))

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -5,6 +5,7 @@ import pytest
 from faculty.clients.experiment import (
     ComparisonOperator,
     CompoundFilter,
+    ExperimentIdFilter,
     ExperimentRunStatus,
     LogicalOperator,
     MetricFilter,
@@ -14,7 +15,42 @@ from faculty.clients.experiment import (
     TagFilter,
 )
 
-from mlflow_faculty.filter import parse_filter_string
+from mlflow_faculty.filter import filter_by_experiment_id, parse_filter_string
+
+
+@pytest.mark.parametrize(
+    "experiment_ids, expected_filter",
+    [
+        ([1], ExperimentIdFilter(ComparisonOperator.EQUAL_TO, 1)),
+        (
+            [1, 2],
+            CompoundFilter(
+                LogicalOperator.OR,
+                [
+                    ExperimentIdFilter(ComparisonOperator.EQUAL_TO, 1),
+                    ExperimentIdFilter(ComparisonOperator.EQUAL_TO, 2),
+                ],
+            ),
+        ),
+        (
+            ["3", "4"],
+            CompoundFilter(
+                LogicalOperator.OR,
+                [
+                    ExperimentIdFilter(ComparisonOperator.EQUAL_TO, 3),
+                    ExperimentIdFilter(ComparisonOperator.EQUAL_TO, 4),
+                ],
+            ),
+        ),
+    ],
+)
+def test_filter_by_experiment_id(experiment_ids, expected_filter):
+    assert filter_by_experiment_id(experiment_ids) == expected_filter
+
+
+def test_filter_by_experiment_id_empty_list():
+    with pytest.raises(ValueError):
+        filter_by_experiment_id([])
 
 
 ATTRIBUTE_IDENTIFIERS = ["attribute", "attributes", "attr", "run"]

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -276,6 +276,11 @@ def test_filter_by_experiment_id(experiment_ids, expected_filter):
     assert filter_by_experiment_id(experiment_ids) == expected_filter
 
 
+def test_filter_by_experiment_id_invalid_id():
+    with pytest.raises(ValueError):
+        filter_by_experiment_id("not a valid integer")
+
+
 def test_filter_by_experiment_id_empty_list():
     with pytest.raises(MatchesNothing):
         filter_by_experiment_id([])

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -282,6 +282,25 @@ def test_parse_filter_string_parentheses(filter_string, expected_filter):
 @pytest.mark.parametrize(
     "filter_string",
     [
+        "param = 'a string'",
+        "alpha = 'a string'",
+        "p.alpha = 'a string'",
+        "attribute.unsupported = 'a string'",
+    ],
+)
+def test_parse_filter_string_invalid_identifier(filter_string):
+    with pytest.raises(ValueError, match="Invalid identifier"):
+        parse_filter_string(filter_string)
+
+
+def test_parse_filter_string_unrecognised_operator():
+    with pytest.raises(ValueError, match="is not a valid operator"):
+        parse_filter_string("param.alpha IN 'a string'")
+
+
+@pytest.mark.parametrize(
+    "filter_string",
+    [
         "param.alpha IS 'a string'",
         "param.alpha = string",
         "metric.accuracy = 'a string'",
@@ -295,4 +314,18 @@ def test_parse_filter_string_parentheses(filter_string, expected_filter):
 )
 def test_parse_filter_string_invalid_value(filter_string):
     with pytest.raises(ValueError, match="Expected .* but found .*"):
+        parse_filter_string(filter_string)
+
+
+@pytest.mark.parametrize(
+    "filter_string",
+    [
+        "run.id > '{}'".format(RUN_ID),
+        "attr.status >= 'FINISHED'",
+        "param.alpha < 'a string'",
+        "tag.`class.name` <= 'a string'",
+    ],
+)
+def test_parse_filter_string_invalid_operator(filter_string):
+    with pytest.raises(ValueError, match="can only be used with operators"):
         parse_filter_string(filter_string)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -16,6 +16,7 @@ from faculty.clients.experiment import (
 
 from mlflow_faculty.filter import parse_filter_string
 
+
 ATTRIBUTE_IDENTIFIERS = ["attribute", "attributes", "attr", "run"]
 
 DEFINED_CASES = [

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -20,7 +20,6 @@ from faculty.clients.experiment import (
     ListExperimentRunsResponse,
     DeleteExperimentRunsResponse,
     RestoreExperimentRunsResponse,
-    Pagination,
     Page,
 )
 from mlflow.entities import RunStatus, RunTag, ViewType


### PR DESCRIPTION
This PR adds support for MLflow filter strings. This has been exposed to users in MLflow 1.2 via `mlflow.search_runs`, allowing querying of run information which is then returned as a DataFrame.

With this PR merged, filter strings like the below can be passed. Filter strings are parsed and passed to the backed as structured filter objects.

- `params.alpha = 0.2`
- `metrics.accuracy > 0.9`
- `tags.mytag = 'hello!'`
- `run.status = 'RUNNING'`

As with MLflow's implementation, the following aliases are supported:

- `param`, `parameter` and `parameters` for `params`
- `metric` for `metrics`
- `tag` for `tags`
- `attribute`, `attributes`, and `attr` for `run`

MLflow also supports filtering by `artifact_uri`, which we do not support.

I have also extended the MLflow logic as follows:

- `run.run_id` (or alias `run.id`) is supported for filtering by run ID.
- Params can be filtered by number and string, as supported by our backend.
- MLflow allows combining individual expressions with `AND` - my implementation also supports `OR` and parentheses, enabling us to encode "is one of these run IDs" in a filter expression. As in the SQL language spec, `AND` is given a higher precedence than `OR`.