### PR TITLE
Fix log artifact with non-null artifact_path

### DIFF
--- a/mlflow_faculty/artifacts.py
+++ b/mlflow_faculty/artifacts.py
@@ -64,8 +64,10 @@ class FacultyDatasetsArtifactRepository(ArtifactRepository):
 
     def log_artifact(self, local_file, artifact_path=None):
         if artifact_path is None:
-            artifact_path = os.path.basename(local_file)
-        datasets_path = self._datasets_path(artifact_path)
+            artifact_path = "./"
+        dest_path = posixpath.join(artifact_path, os.path.basename(local_file))
+
+        datasets_path = self._datasets_path(dest_path)
         datasets.put(local_file, datasets_path, self.project_id)
 
     def log_artifacts(self, local_dir, artifact_path=None):

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -14,6 +14,7 @@
 
 
 from uuid import uuid4
+import posixpath
 
 import pytest
 
@@ -52,15 +53,23 @@ def test_faculty_repo_invalid_uri(uri, message):
         FacultyDatasetsArtifactRepository(uri)
 
 
-@pytest.mark.parametrize("prefix", ["", "/"])
-def test_faculty_repo_log_artifact(mocker, prefix):
+@pytest.mark.parametrize("slash_prefix", ["", "/"])
+@pytest.mark.parametrize("remote_prefix", ["", "remote"])
+@pytest.mark.parametrize("slash_suffix", ["", "/"])
+def test_faculty_repo_log_artifact(
+    mocker, slash_prefix, remote_prefix, slash_suffix
+):
     mocker.patch("faculty.datasets.put")
 
     repo = FacultyDatasetsArtifactRepository(ARTIFACT_URI)
-    repo.log_artifact("/local/file.txt", prefix + "remote/object.txt")
+    repo.log_artifact(
+        "/local/file.txt", slash_prefix + remote_prefix + slash_suffix
+    )
+
+    remote_path = posixpath.join(remote_prefix, "file.txt")
 
     faculty.datasets.put.assert_called_once_with(
-        "/local/file.txt", ARTIFACT_ROOT + "remote/object.txt", PROJECT_ID
+        "/local/file.txt", ARTIFACT_ROOT + remote_path, PROJECT_ID
     )
 
 
@@ -72,19 +81,6 @@ def test_faculty_repo_log_artifact_default_destination(mocker):
 
     faculty.datasets.put.assert_called_once_with(
         "/local/file.txt", ARTIFACT_ROOT + "file.txt", PROJECT_ID
-    )
-
-
-@pytest.mark.parametrize("prefix", ["", "/"])
-@pytest.mark.parametrize("suffix", ["", "/"])
-def test_faculty_repo_log_artifact_to_prefix(mocker, prefix, suffix):
-    mocker.patch("faculty.datasets.put")
-
-    repo = FacultyDatasetsArtifactRepository(ARTIFACT_URI)
-    repo.log_artifact("/local/file.txt", prefix + "remote" + suffix)
-
-    faculty.datasets.put.assert_called_once_with(
-        "/local/file.txt", ARTIFACT_ROOT + "remote/file.txt", PROJECT_ID
     )
 
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -76,6 +76,19 @@ def test_faculty_repo_log_artifact_default_destination(mocker):
 
 
 @pytest.mark.parametrize("prefix", ["", "/"])
+@pytest.mark.parametrize("suffix", ["", "/"])
+def test_faculty_repo_log_artifact_to_prefix(mocker, prefix, suffix):
+    mocker.patch("faculty.datasets.put")
+
+    repo = FacultyDatasetsArtifactRepository(ARTIFACT_URI)
+    repo.log_artifact("/local/file.txt", prefix + "remote" + suffix)
+
+    faculty.datasets.put.assert_called_once_with(
+        "/local/file.txt", ARTIFACT_ROOT + "remote/file.txt", PROJECT_ID
+    )
+
+
+@pytest.mark.parametrize("prefix", ["", "/"])
 def test_faculty_repo_log_artifacts(mocker, prefix):
     mocker.patch("faculty.datasets.put")
 


### PR DESCRIPTION
In the migration to use datasets for artifact logging we changed how we used the `artifact_path` argument of `log_artifact` from being a prefix on the remote store to being the remote file path. This PR restores the former behaviour, which is in accordance with the MLflow artifact stores (see, e.g., the [`mlflow.store.S3ArtifactRepository`](https://github.com/mlflow/mlflow/blob/master/mlflow/store/s3_artifact_repo.py#L31), in which the local file name is appended to the `artifact_path` argument).

