### PR TITLE
Make compatible with open source tracking server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ dist/
 pytest_cache/
 __pycache__/
 *.pyc
-.tox
+.tox/
+pip-wheel-metadata/

--- a/mlflow_faculty/artifacts.py
+++ b/mlflow_faculty/artifacts.py
@@ -27,6 +27,9 @@ from mlflow_faculty.converters import faculty_object_to_mlflow_file_info
 
 class FacultyDatasetsArtifactRepository(ArtifactRepository):
     def __init__(self, artifact_uri):
+
+        super(FacultyDatasetsArtifactRepository, self).__init__(artifact_uri)
+
         parsed_uri = urllib.parse.urlparse(artifact_uri)
         if parsed_uri.scheme != "faculty-datasets":
             raise ValueError(

--- a/mlflow_faculty/converters.py
+++ b/mlflow_faculty/converters.py
@@ -74,7 +74,7 @@ _LIFECYCLE_STAGE_CONVERSION_MAP = {
 
 
 def _datetime_to_mlflow_timestamp(dt):
-    return to_timestamp(dt) * 1000
+    return int(to_timestamp(dt) * 1000)
 
 
 def faculty_experiment_to_mlflow_experiment(faculty_experiment):

--- a/mlflow_faculty/converters.py
+++ b/mlflow_faculty/converters.py
@@ -129,7 +129,7 @@ def faculty_run_to_mlflow_run(faculty_run):
 
     run_info = RunInfo(
         run_uuid=faculty_run.id.hex,
-        experiment_id=faculty_run.experiment_id,
+        experiment_id=str(faculty_run.experiment_id),
         user_id="",
         status=_FACULTY_TO_MLFLOW_RUN_STATUS_MAP[faculty_run.status],
         start_time=start_time,

--- a/mlflow_faculty/converters.py
+++ b/mlflow_faculty/converters.py
@@ -80,7 +80,7 @@ def _datetime_to_mlflow_timestamp(dt):
 def faculty_experiment_to_mlflow_experiment(faculty_experiment):
     active = faculty_experiment.deleted_at is None
     return Experiment(
-        faculty_experiment.id,
+        str(faculty_experiment.id),
         faculty_experiment.name,
         faculty_experiment.artifact_location,
         LifecycleStage.ACTIVE if active else LifecycleStage.DELETED,

--- a/mlflow_faculty/tracking.py
+++ b/mlflow_faculty/tracking.py
@@ -97,6 +97,9 @@ class FacultyRestStore(AbstractStore):
 
         :return: experiment_id (integer) for the newly created experiment.
         """
+        if artifact_location == "":
+            # Assume unspecified artifact location
+            artifact_location = None
         try:
             faculty_experiment = self._client.create(
                 self._project_id, name, artifact_location=artifact_location

--- a/mlflow_faculty/tracking.py
+++ b/mlflow_faculty/tracking.py
@@ -95,7 +95,7 @@ class FacultyRestStore(AbstractStore):
         :param artifact_location: Base location for artifacts in runs. May be
             None.
 
-        :return: experiment_id (integer) for the newly created experiment.
+        :return: experiment_id (string) for the newly created experiment.
         """
         if artifact_location == "":
             # Assume unspecified artifact location
@@ -109,7 +109,7 @@ class FacultyRestStore(AbstractStore):
         except faculty.clients.base.HttpError as e:
             raise faculty_http_error_to_mlflow_exception(e)
         else:
-            return faculty_experiment.id
+            return str(faculty_experiment.id)
 
     def get_experiment(self, experiment_id):
         """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -102,7 +102,9 @@ FACULTY_RUN = ExperimentRun(
 
 
 def mlflow_experiment(lifecycle_stage=LifecycleStage.ACTIVE):
-    return Experiment(EXPERIMENT_ID, NAME, ARTIFACT_LOCATION, lifecycle_stage)
+    return Experiment(
+        str(EXPERIMENT_ID), NAME, ARTIFACT_LOCATION, lifecycle_stage
+    )
 
 
 def mlflow_run(
@@ -121,7 +123,7 @@ def mlflow_run(
     data = RunData(params=[MLFLOW_PARAM], metrics=[MLFLOW_METRIC], tags=tags)
     info = RunInfo(
         run_uuid=RUN_UUID_HEX_STR,
-        experiment_id=EXPERIMENT_ID,
+        experiment_id=str(EXPERIMENT_ID),
         user_id="",
         status=status,
         start_time=RUN_STARTED_AT_MILLISECONDS,

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -105,7 +105,7 @@ def test_create_experiment(mocker):
     store = FacultyRestStore(STORE_URI)
     experiment_id = store.create_experiment(NAME, ARTIFACT_LOCATION)
 
-    assert experiment_id == FACULTY_EXPERIMENT.id
+    assert experiment_id == str(FACULTY_EXPERIMENT.id)
     mock_client.create.assert_called_once_with(
         PROJECT_ID, NAME, artifact_location=ARTIFACT_LOCATION
     )


### PR DESCRIPTION
To support R, we need to match some additional assumptions made by the open source tracking server so we can have it proxy calls to the Faculty tracking service.