### PR TITLE
Fix multilevel artifact downloads

### DIFF
--- a/mlflow_faculty/artifacts.py
+++ b/mlflow_faculty/artifacts.py
@@ -123,8 +123,8 @@ class FacultyDatasetsArtifactRepository(ArtifactRepository):
         return [
             i
             for i in infos
-            if i.path not in ["/", "."]
-            and (os.path.dirname(i.path) in ["", path] or recursive)
+            if i.path not in {"/", "."}
+            and (os.path.dirname(i.path) in {"", path} or recursive)
         ]
 
     def _download_file(self, remote_file_path, local_path):

--- a/mlflow_faculty/artifacts.py
+++ b/mlflow_faculty/artifacts.py
@@ -78,7 +78,20 @@ class FacultyDatasetsArtifactRepository(ArtifactRepository):
         datasets_path = self._datasets_path(artifact_path)
         datasets.put(local_dir, datasets_path, self.project_id)
 
-    def list_artifacts(self, path=None):
+    def list_artifacts(self, path=None, recursive=False):
+        """List artifacts from a repository.
+
+        Args:
+            path (str, optional): the artifact path to list. Defaults
+                to None, to list from the root of the dataset.
+            recursive (bool, optional): if False, list the artifacts
+                in the current path (single file, or contents of a single
+                directory level), otherwise list all artifacts without
+                limits. Defaults to False.
+
+        Returns:
+            List of mlflow.entities.FileInfo objects.
+        """
         if path is None:
             path = "./"
         datasets_path = self._datasets_path(path)
@@ -105,9 +118,14 @@ class FacultyDatasetsArtifactRepository(ArtifactRepository):
             )
             for obj in objects
         ]
-
-        # Remove root
-        return [i for i in infos if i.path != "/"]
+        # Remove root and only list the items directly in the requested path,
+        # without traversing subdirectories
+        return [
+            i
+            for i in infos
+            if i.path not in ["/", "."]
+            and (os.path.dirname(i.path) in ["", path] or recursive)
+        ]
 
     def _download_file(self, remote_file_path, local_path):
         datasets_path = self._datasets_path(remote_file_path)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -181,7 +181,7 @@ def test_faculty_repo_list_artifacts_selective_directory(mocker, suffix):
     # or entries in the "current folder" in all situations, which result in
     # empty dirname.
     mock_file_infos_correct = [
-        f for f in mock_file_infos if os.path.dirname(f.path) in ["", target]
+        f for f in mock_file_infos if os.path.dirname(f.path) in {"", target}
     ]
 
     repo = FacultyDatasetsArtifactRepository(ARTIFACT_URI)


### PR DESCRIPTION
Models can be registered with subfolders, for example such as:
```
test
├── subdir
│   └── sub.file
└── top.file
```

In the current form, when one requests this model, the library downloads all files, but the files from the subdirectories are downloaded multiple times: in the root, and also in their subfolder (and along all
the subfolders, if there are even more levels):
```
test
├── subdir
│   └── sub.file
├── sub.file
└── top.file
```
This is because `mlflow` expects a list of files & directories in a path, but doesn't expect all the items recursively within a subdir, since there are extra steps when they traverse those subdirectories.

With this change, when `mlflow` requests a list of artifacts at a given path, only return the files and directories directly there, and filter out all other recursive items (which `mlflow` will request later on).

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>